### PR TITLE
Add parallel processing and caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+- Make docstrfmt operate in parallel when processing more than 2 files similar to
+  psf/black.
+- Added a caching mechanism similar to psf/black has so files that haven't changed from
+  the last run won't be checked again.
+
 1.0.3 (2021/01/23)
 ------------------
 

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -125,6 +125,7 @@ class CodeFormatters:
             try:
                 compile(code, context.current_file, mode="exec")
             except SyntaxError as syntax_error:
+                context.manager.error_count += 1
                 with open(context.current_file, encoding="utf-8") as f:
                     source = f.read()
                 current_line = get_code_line(source, code)
@@ -896,6 +897,7 @@ class Manager:
     def __init__(self, reporter, black_config=None, docstring_trailing_line=True):
         rst_extras.register()
         self.black_config = black_config
+        self.error_count = 0
         self.reporter = reporter
         self.settings = OptionParser(components=[rst.Parser]).get_default_values()
         self.settings.smart_quotes = True
@@ -922,6 +924,7 @@ class Manager:
             and child.attributes["type"] != "INFO"
         ]
         if errors:
+            self.error_count += len(errors)
             raise InvalidRstErrors(
                 [
                     InvalidRstError(

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -1,7 +1,14 @@
+import asyncio
 import contextlib
 import glob
+import os
+import signal
 import sys
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from copy import copy
+from functools import partial
+from multiprocessing import Manager as MultiManager
+from multiprocessing import freeze_support
 from os.path import abspath, basename
 from pathlib import Path
 from textwrap import dedent, indent
@@ -13,8 +20,10 @@ from black import (
     PY36_VERSIONS,
     Mode,
     TargetVersion,
+    cancel,
     find_pyproject_toml,
     parse_pyproject_toml,
+    shutdown,
 )
 from click import Context
 from libcst import CSTTransformer, Expr
@@ -24,31 +33,12 @@ from docstrfmt.const import __version__
 from docstrfmt.debug import dump_node
 from docstrfmt.docstrfmt import Manager
 from docstrfmt.exceptions import InvalidRstErrors
-from docstrfmt.util import plural
+from docstrfmt.util import FileCache, plural
 
 if TYPE_CHECKING:  # pragma: no cover
     from libcst import AssignTarget, ClassDef, FunctionDef, Module, SimpleString
 
-
-class Reporter:
-    def __init__(self, level=1):
-        self.level = level
-        self.error_count = 0
-
-    def _log_message(self, message, level, **formatting_kwargs):
-        if self.level >= level:
-            click.secho(message, err=True, **formatting_kwargs)
-
-    def debug(self, message, **formatting_kwargs):
-        self._log_message(message, 3, bold=False, fg="blue", **formatting_kwargs)
-
-    def error(self, message, **formatting_kwargs):
-        self.error_count += 1
-        self._log_message(message, -1, bold=False, fg="red", **formatting_kwargs)
-
-    def print(self, message, level=0, **formatting_kwargs):
-        formatting_kwargs.setdefault("bold", level == 0)
-        self._log_message(message, level, **formatting_kwargs)
+echo = partial(click.secho, err=True)
 
 
 # Define this here to support Python <3.7.
@@ -61,6 +51,31 @@ class nullcontext(contextlib.AbstractContextManager):  # type: ignore
 
     def __exit__(self, *excinfo: Any) -> Any:
         pass
+
+
+class Reporter:
+    def __init__(self, level=1):
+        self.level = level
+        self.error_count = 0
+
+    def _log_message(self, message, level, **formatting_kwargs):
+        if self.level >= level:
+            echo(message, **formatting_kwargs)
+            sys.stderr.flush()
+            sys.stdout.flush()
+
+    def debug(self, message, **formatting_kwargs):
+        self._log_message(message, 3, bold=False, fg="blue", **formatting_kwargs)
+
+    def error(self, message, **formatting_kwargs):
+        self._log_message(message, -1, bold=False, fg="red", **formatting_kwargs)
+
+    def print(self, message, level=0, **formatting_kwargs):
+        formatting_kwargs.setdefault("bold", level == 0)
+        self._log_message(message, level, **formatting_kwargs)
+
+
+reporter = Reporter(0)
 
 
 class Visitor(CSTTransformer):
@@ -76,6 +91,7 @@ class Visitor(CSTTransformer):
         self.line_length = line_length
         self.manager = manager
         self.misformatted = False
+        self.error_count = 0
 
     def _is_docstring(self, node: "SimpleString") -> bool:
         return node.quote.startswith(('"""', "'''")) and isinstance(
@@ -106,13 +122,16 @@ class Visitor(CSTTransformer):
                 (" " * indent_level) + original_node.evaluated_value
             ).rstrip()
             doc = self.manager.parse_string(self.file, source)
-            if self.manager.reporter.level >= 3:
-                self.manager.reporter.debug("=" * 60)
-                self.manager.reporter.debug(dump_node(doc))
+            if reporter.level >= 3:
+                reporter.debug("=" * 60)
+                reporter.debug(dump_node(doc))
             width = self.line_length - indent_level
             if width < 1:
+                self.error_count += 1
                 raise ValueError(f"Invalid starting width {self.line_length}")
             output = self.manager.format_node(width, doc, True).rstrip()
+            self.error_count += self.manager.error_count
+            self.manager.error_count = 0
             object_display_name = (
                 f'{self._object_type} {".".join(self._object_names)!r}'
             )
@@ -125,14 +144,14 @@ class Visitor(CSTTransformer):
             else:
                 correct_ending = int(self._blank_line) + 1 == end_line_count
             if source == output and correct_ending:
-                self.manager.reporter.print(
-                    f"Docstring for {object_display_name} in file {self.file!r} is formatted correctly. Nice!",
+                reporter.print(
+                    f"Docstring for {object_display_name} in file {str(self.file)!r} is formatted correctly. Nice!",
                     1,
                 )
             else:
                 self.misformatted = True
                 file_link = f'File "{self.file}"'
-                self.manager.reporter.print(
+                reporter.print(
                     f"Found incorrectly formatted docstring. Docstring for {object_display_name} in {file_link}.",
                     1,
                 )
@@ -164,6 +183,136 @@ class Visitor(CSTTransformer):
     def visit_Module(self, node: "Module") -> Optional[bool]:
         self._object_type = "module"
         return True
+
+
+async def _run_formatter(
+    check,
+    file_type,
+    files,
+    include_txt,
+    docstring_trailing_line,
+    mode,
+    raw_output,
+    cache,
+    loop,
+    executor,
+):
+    # This code is heavily based on that of psf/black
+    # see here for license: https://github.com/psf/black/blob/master/LICENSE
+    todo, already_done = cache.gen_todo_list(files)
+    cancelled = []
+    files_to_cache = []
+    lock = MultiManager().Lock()
+    line_length = mode.line_length
+    misformatted_files = set()
+    tasks = {
+        asyncio.ensure_future(
+            loop.run_in_executor(
+                executor,
+                _format_file,
+                check,
+                file,
+                file_type,
+                include_txt,
+                line_length,
+                mode,
+                docstring_trailing_line,
+                raw_output,
+                lock,
+            )
+        ): file
+        for file in sorted(todo)
+    }
+    in_process = tasks.keys()
+    try:
+        loop.add_signal_handler(signal.SIGINT, cancel, in_process)
+        loop.add_signal_handler(signal.SIGTERM, cancel, in_process)
+    except NotImplementedError:  # pragma: no cover
+        # There are no good alternatives for these on Windows.
+        pass
+    error_count = 0
+    while in_process:
+        done, _ = await asyncio.wait(in_process, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            file = tasks.pop(task)
+            if task.cancelled():  # pragma: no cover
+                cancelled.append(task)
+            elif task.exception():  # pragma: no cover
+                reporter.error(str(task.exception()))
+                error_count += 1
+            else:
+                misformatted, errors = task.result()
+                sys.stderr.flush()
+                error_count += errors
+                if misformatted:
+                    misformatted_files.add(file)
+                if (
+                    not (misformatted and raw_output) or (check and not misformatted)
+                ) and errors == 0:
+                    files_to_cache.append(file)
+    if cancelled:  # pragma: no cover
+        await asyncio.gather(*cancelled, loop=loop, return_exceptions=True)
+    if files_to_cache:
+        cache.write_cache(files_to_cache)
+    return misformatted_files, error_count
+
+
+def _format_file(
+    check,
+    file,
+    file_type,
+    include_txt,
+    line_length,
+    mode,
+    docstring_trailing_line,
+    raw_output,
+    lock,
+):
+    error_count = 0
+    manager = Manager(reporter, mode, docstring_trailing_line)
+    if file.name == "-":
+        raw_output = True
+    reporter.print(f"Checking {file}", 2)
+    misformatted = False
+    with nullcontext(sys.stdin) if file.name == "-" else open(
+        file, encoding="utf-8"
+    ) as f:
+        input_string = f.read()
+    try:
+        if file.suffix == ".py" or (file_type == "py" and file.name == "-"):
+            misformatted, errors = _process_python(
+                check,
+                file,
+                input_string,
+                line_length,
+                manager,
+                raw_output,
+                lock,
+            )
+            error_count += errors
+        elif (
+            file.suffix in ([".rst", ".txt"] if include_txt else [".rst"])
+            or file.name == "-"
+        ):
+            misformatted, errors = _process_rst(
+                check,
+                file,
+                input_string,
+                line_length,
+                manager,
+                raw_output,
+                lock,
+            )
+            error_count += errors
+    except InvalidRstErrors as errors:
+        reporter.error(str(errors))
+        error_count += 1
+        reporter.print(f"Failed to format {str(file)!r}")
+    except Exception as error:
+        reporter.error(f"{error.__class__.__name__}: {error}")
+        error_count += 1
+        reporter.print(f"Failed to format {str(file)!r}")
+    return misformatted, error_count
 
 
 def _parse_pyproject_config(
@@ -222,7 +371,7 @@ def _parse_sources(
 
 
 def _process_python(
-    check, file, input_string, line_length, manager, misformatted, raw_output
+    check, file, input_string, line_length, manager, raw_output, lock=None
 ):
     filename = basename(file)
     object_name = filename.split(".")[0]
@@ -230,72 +379,63 @@ def _process_python(
     module = cst.parse_module(input_string)
     wrapper = cst.MetadataWrapper(module)
     result = wrapper.visit(visitor)
+    error_count = visitor.error_count
+    misformatted = False
     if visitor.misformatted:
-        misformatted.add(file)
+        misformatted = True
         if check and not raw_output:
-            manager.reporter.print(f"File {file!r} could be reformatted.")
+            reporter.print(f"File {str(file)!r} could be reformatted.")
         else:
-            _write_output(
-                file,
-                manager.reporter,
-                result.code,
-                (
-                    nullcontext(sys.stdout)
-                    if file == "-" or raw_output
-                    else open(file, "w", encoding="utf-8")
-                ),
-                raw_output,
-            )
+            if file == "-" or raw_output:
+                with lock or nullcontext():
+                    _write_output(
+                        file, result.code, nullcontext(sys.stdout), raw_output
+                    )
+            else:
+                _write_output(
+                    file, result.code, open(file, "w", encoding="utf-8"), raw_output
+                )
     elif raw_output:
-        _write_output(
-            file, manager.reporter, input_string, nullcontext(sys.stdout), raw_output
-        )
-    return misformatted
+        with lock or nullcontext():
+            _write_output(file, input_string, nullcontext(sys.stdout), raw_output)
+    return misformatted, error_count
 
 
 def _process_rst(
-    check, file, input_string, line_length, manager, misformatted, raw_output
+    check, file, input_string, line_length, manager, raw_output, lock=None
 ):
     doc = manager.parse_string(file, input_string)
-    if manager.reporter.level >= 3:
-        manager.reporter.debug("=" * 60)
-        manager.reporter.debug(dump_node(doc))
+    if reporter.level >= 3:
+        reporter.debug("=" * 60)
+        reporter.debug(dump_node(doc))
     output = manager.format_node(line_length, doc)
+    error_count = manager.error_count
+    misformatted = False
     if output == input_string:
-        manager.reporter.print(f"File {file!r} is formatted correctly. Nice!", 1)
+        reporter.print(f"File {str(file)!r} is formatted correctly. Nice!", 1)
         if raw_output:
-            _write_output(
-                file,
-                manager.reporter,
-                input_string,
-                nullcontext(sys.stdout),
-                raw_output,
-            )
-            return misformatted
+            with lock or nullcontext():
+                _write_output(file, input_string, nullcontext(sys.stdout), raw_output)
     else:
-        misformatted.add(file)
+        misformatted = True
         if check and not raw_output:
-            manager.reporter.print(f"File {file!r} could be reformatted.")
+            reporter.print(f"File {str(file)!r} could be reformatted.")
         else:
-            _write_output(
-                file,
-                manager.reporter,
-                output,
-                (
-                    nullcontext(sys.stdout)
-                    if file == "-" or raw_output
-                    else open(file, "w", encoding="utf-8")
-                ),
-                raw_output,
-            )
-    return misformatted
+            if file == "-" or raw_output:
+                with lock or nullcontext():
+                    _write_output(file, output, nullcontext(sys.stdout), raw_output)
+            else:
+                _write_output(
+                    file, output, open(file, "w", encoding="utf-8"), raw_output
+                )
+    return misformatted, error_count
 
 
-def _write_output(file, reporter, output, output_manager, raw):
+def _write_output(file, output, output_manager, raw):
     with output_manager as f:
         f.write(output)
     if not raw:
-        reporter.print(f"Reformatted {file!r}.")
+        reporter.print(f"Reformatted {str(file)!r}.")
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
@@ -416,93 +556,111 @@ def main(
     docstring_trailing_line: bool,
     files: List[str],
 ) -> None:
-    reporter = Reporter(verbose)
+    reporter.level = verbose
     if "-" in files and len(files) > 1:
         reporter.error("ValueError: stdin can not be used with other paths")
         context.exit(2)
     if quiet or raw_output or files == ["-"]:
         reporter.level = -1
-    manager = Manager(reporter, mode, docstring_trailing_line)
-    misformatted = set()
+    misformatted_files = set()
 
     if line_length != 88:
         mode.line_length = line_length
-
+    error_count = 0
     if raw_input:
+        manager = Manager(reporter, mode, docstring_trailing_line)
         file = "<raw_input>"
         check = False
         try:
+            misformatted = False
             if file_type == "py":
-                misformatted = _process_python(
-                    check, file, raw_input, line_length, manager, misformatted, True
+                misformatted, _ = _process_python(
+                    check, file, raw_input, line_length, manager, True
                 )
             elif file_type == "rst":
-                misformatted = _process_rst(
-                    check, file, raw_input, line_length, manager, misformatted, True
+                misformatted, _ = _process_rst(
+                    check, file, raw_input, line_length, manager, True
                 )
+            if misformatted:
+                misformatted_files.add(file)
         except InvalidRstErrors as errors:
             reporter.error(str(errors))
             context.exit(1)
-
         context.exit(0)
-    line_length = mode.line_length
-    for file in files:
-        if file == "-":
-            raw_output = True
-        reporter.print(f"Checking {file}", 2)
-        with nullcontext(sys.stdin) if file == "-" else open(
-            file, encoding="utf-8"
-        ) as f:
-            input_string = f.read()
-        try:
-            if file.endswith(".py") or (file_type == "py" and file == "-"):
-                misformatted = _process_python(
-                    check,
-                    file,
-                    input_string,
-                    line_length,
-                    manager,
-                    misformatted,
-                    raw_output,
-                )
-            elif file.endswith(("rst", "txt") if include_txt else "rst") or file == "-":
-                misformatted = _process_rst(
-                    check,
-                    file,
-                    input_string,
-                    line_length,
-                    manager,
-                    misformatted,
-                    raw_output,
-                )
-        except InvalidRstErrors as errors:
-            reporter.error(str(errors))
-            reporter.print(f"Failed to format {file!r}")
-        except Exception as error:
-            reporter.error(f"{error.__class__.__name__}: {error}")
-            reporter.print(f"Failed to format {file!r}")
 
-    if misformatted and not raw_output:
+    cache = FileCache(context)
+    if len(files) < 2:
+        for file in files:
+            misformatted, error_count = _format_file(
+                check,
+                Path(file),
+                file_type,
+                include_txt,
+                line_length,
+                mode,
+                docstring_trailing_line,
+                raw_output,
+                None,
+            )
+            if misformatted:
+                misformatted_files.add(file)
+
+    else:
+        # This code is heavily based on that of psf/black
+        # see here for license: https://github.com/psf/black/blob/master/LICENSE
+        executor = None
+        loop = asyncio.get_event_loop()
+        worker_count = os.cpu_count()
+        if sys.platform == "win32":  # pragma: no cover
+            # Work around https://bugs.python.org/issue26903
+            worker_count = min(worker_count, 61)
+        try:
+            executor = ProcessPoolExecutor(max_workers=worker_count)
+        except (ImportError, OSError):  # pragma: no cover
+            # we arrive here if the underlying system does not support multi-processing
+            # like in AWS Lambda or Termux, in which case we gracefully fallback to
+            # a ThreadPollExecutor with just a single worker (more workers would not do us
+            # any good due to the Global Interpreter Lock)
+            executor = ThreadPoolExecutor(max_workers=1)
+        try:
+            misformatted_files, error_count = loop.run_until_complete(
+                _run_formatter(
+                    check,
+                    file_type,
+                    files,
+                    include_txt,
+                    docstring_trailing_line,
+                    mode,
+                    raw_output,
+                    cache,
+                    loop,
+                    executor,
+                )
+            )
+        finally:
+            shutdown(loop)
+            if executor is not None:
+                executor.shutdown()
+    if misformatted_files and not raw_output:
         if check:
             reporter.print(
-                f"{len(misformatted)} out of {plural('file', len(files))} could be reformatted."
+                f"{len(misformatted_files)} out of {plural('file', len(files))} could be reformatted."
             )
         else:
             reporter.print(
-                f"{len(misformatted)} out of {plural('file', len(files))} were reformatted."
+                f"{len(misformatted_files)} out of {plural('file', len(files))} were reformatted."
             )
     elif not raw_output:
         reporter.print(f"{plural('file', len(files))} were checked.")
-    if reporter.error_count > 0:
-        reporter.print(
-            f"Done, but {plural('error', reporter.error_count)} occurred ❌💥❌"
-        )
+    if error_count > 0:
+        reporter.print(f"Done, but {plural('error', error_count)} occurred ❌💥❌")
     elif not raw_output:
         reporter.print("Done! 🎉")
-    if (check and misformatted) or reporter.error_count:
+    if (check and misformatted_files) or error_count:
         context.exit(1)
     context.exit(0)
 
 
 if __name__ == "__main__":  # pragma: no cover
+    freeze_support()
     main()

--- a/docstrfmt/util.py
+++ b/docstrfmt/util.py
@@ -1,5 +1,78 @@
+import os
+import pickle
+import tempfile
+from copy import copy
+from pathlib import Path
+
+from appdirs import user_cache_dir
 from docutils.parsers.rst.states import ParserError
 from docutils.utils import roman
+
+from .const import __version__
+
+
+class FileCache:
+    def __init__(self, context):
+        self.cache_dir = Path(user_cache_dir("docstrfmt", version=__version__))
+        self.context = context
+        self.cache = self.read_cache()
+
+    @staticmethod
+    def get_file_info(file):
+        file_info = file.stat()
+        return file_info.st_mtime, file_info.st_size
+
+    def gen_todo_list(self, files):
+        todo, done = set(), set()
+        for file in files:
+            file = Path(file)
+            file = file.resolve()
+            if self.cache.get(file) != self.get_file_info(file):
+                todo.add(file)
+            else:  # pragma: no cover
+                done.add(file)
+        return todo, done
+
+    def get_cache_filename(self):
+        mode = copy(self.context.params["mode"].__dict__)
+        mode["target_versions"] = ",".join(
+            sorted([str(version.value) for version in mode["target_versions"]])
+        )
+        docstring_trailing_line = str(self.context.params["docstring_trailing_line"])
+        line_length = str(self.context.params["line_length"])
+        mode = "_".join([str(mode[key]) for key in sorted(mode)])
+        include_txt = str(self.context.params["include_txt"])
+        return (
+            self.cache_dir
+            / f"cache.{'_'.join([docstring_trailing_line, line_length, mode, include_txt])}.pickle"
+        )
+
+    def read_cache(self):
+        cache_file = self.get_cache_filename()
+        if not cache_file.exists():
+            return {}
+        with cache_file.open("rb") as f:
+            try:
+                return pickle.load(f)
+            except (pickle.UnpicklingError, ValueError):  # pragma: no cover
+                return {}
+
+    def write_cache(self, files) -> None:
+        """Update the cache file."""
+        cache_file = self.get_cache_filename()
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+            new_cache = {
+                **self.cache,
+                **{file.resolve(): self.get_file_info(file) for file in files},
+            }
+            with tempfile.NamedTemporaryFile(
+                dir=str(cache_file.parent), delete=False
+            ) as f:
+                pickle.dump(new_cache, f, protocol=4)
+            os.replace(f.name, cache_file)
+        except OSError:  # pragma: no cover
+            pass
 
 
 def get_code_line(current_source, code):
@@ -9,11 +82,13 @@ def get_code_line(current_source, code):
     for line_number, line in enumerate(lines, 1):
         if code_lines[0] in line:
             if multiple:
+                current_offset = 0
                 for offset, sub_line in enumerate(code_lines):
+                    current_offset = offset
                     if sub_line not in lines[line_number - 1 + offset]:
                         break
                 else:
-                    return line_number
+                    return line_number + current_offset
             else:
                 return line_number
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def manager():
 
 
 @pytest.fixture
-def runner():
+def runner(loop):
     runner = CliRunner()
     files_to_copy = os.path.abspath("tests/test_files")
     with runner.isolated_filesystem() as temp_dir:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,19 +61,19 @@ def test_encoding_raw_output(runner):
     file = "tests/test_files/test_encoding.rst"
     args = ["-o", file]
     result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
     assert (
         result.output
         == ".. note::\n\n    á Á à À â Â ä Ä ã Ã å Å æ Æ ç Ç é É è È ê Ê ë Ë í Í ì Ì î Î ï Ï ñ Ñ ó Ó ò Ò ô Ô ö Ö.\n    õ Õ ø Ø œ Œ ß ú Ú ù Ù û Û ü Ü á Á à À â Â ä Ä ã Ã å Å æ Æ ç Ç é É è È ê Ê ë Ë í Í ì.\n"
     )
-    assert result.exit_code == 0
 
 
 def test_encoding_stdin(runner):
     file = ".. note::\n\n    á Á à À â Â ä Ä ã Ã å Å æ Æ ç Ç é É è È ê Ê ë Ë í Í ì Ì î Î ï Ï ñ Ñ ó Ó ò Ò ô Ô ö Ö.\n    õ Õ ø Ø œ Œ ß ú Ú ù Ù û Û ü Ü á Á à À â Â ä Ä ã Ã å Å æ Æ ç Ç é É è È ê Ê ë Ë í Í ì.\n"
     args = ["-"]
     result = runner.invoke(main, args=args, input=file)
-    assert result.output == file
     assert result.exit_code == 0
+    assert result.output == file
 
 
 def test_exclude(runner):
@@ -97,39 +97,39 @@ def test_globbing(runner, file):
         file,
     ]
     result = runner.invoke(main, args=args)
-    assert result.output.startswith("Reformatted")
     assert result.exit_code == 0
+    assert result.output.endswith("were reformatted.\nDone! 🎉\n")
 
 
 def test_include_txt(runner):
     args = ["-l", 80, "-T", "tests/test_files/test_file.txt"]
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
-    assert result.output.startswith("Reformatted")
+    assert result.output.endswith("1 out of 1 file were reformatted.\nDone! 🎉\n")
 
 
 def test_invalid_code_block_rst(runner):
     file = "tests/test_files/test_invalid_syntax.rst"
     result = runner.invoke(main, args=[file])
+    assert result.exit_code == 1
     assert result.output.startswith(
         f'SyntaxError: EOL while scanning string literal:\n\nFile "{os.path.abspath(file)}", line 3:'
     )
     assert result.output.endswith(
         "1 file were checked.\nDone, but 1 error occurred ❌💥❌\n"
     )
-    assert result.exit_code == 1
 
 
 def test_invalid_code_block_py(runner):
     file = "tests/test_files/py_file_error_bad_codeblock.py"
     result = runner.invoke(main, args=[file])
+    assert result.exit_code == 1
     assert result.output.startswith(
-        f'SyntaxError: EOL while scanning string literal:\n\nFile "{os.path.abspath(file)}", line 43:'
+        f'SyntaxError: EOL while scanning string literal:\n\nFile "{os.path.abspath(file)}", line 44:'
     )
     assert result.output.endswith(
         "1 file were checked.\nDone, but 2 errors occurred ❌💥❌\n"
     )
-    assert result.exit_code == 1
 
 
 @pytest.mark.parametrize(
@@ -155,6 +155,7 @@ def test_invalid_rst_file(runner):
 def test_invalid_table(runner):
     file = "tests/test_files/test_invalid_table.rst"
     result = runner.invoke(main, args=[file])
+    assert result.exit_code == 1
     assert result.output.startswith(
         "NotImplementedError: Tables with cells that span "
         "multiple cells are not supported. Consider using "
@@ -164,7 +165,6 @@ def test_invalid_table(runner):
     assert result.output.endswith(
         "1 file were checked.\nDone, but 1 error occurred ❌💥❌\n"
     )
-    assert result.exit_code == 1
 
 
 @pytest.mark.parametrize("length", test_line_length)
@@ -173,7 +173,7 @@ def test_invalid_table(runner):
 )
 def test_line_length(runner, length, file):
     args = ["-l", length, file]
-    result = runner.invoke(main, args=args)
+    result = runner.invoke(main, args=args, catch_exceptions=False)
     assert result.exit_code == 0
     assert result.output.startswith("Reformatted")
     result = runner.invoke(main, args=args)
@@ -220,10 +220,10 @@ def test_raw_input_rst_error(runner):
         raw_file = f.read()
     args = ["-t", "rst", "-r", raw_file]
     result = runner.invoke(main, args=args)
+    assert result.exit_code == 1
     assert result.output.startswith(
         'ERROR: File "<raw_input>", line 1:\nUnknown directive type "codeblock".'
     )
-    assert result.exit_code == 1
 
 
 def test_raw_input_rst_errors_py(runner):
@@ -232,10 +232,10 @@ def test_raw_input_rst_errors_py(runner):
         raw_file = f.read()
     args = ["-t", "py", "-r", raw_file]
     result = runner.invoke(main, args=args)
+    assert result.exit_code == 1
     assert result.output.startswith(
         'ERROR: File "<raw_input>", line 6:\nUnknown directive type "codeblock".'
     )
-    assert result.exit_code == 1
 
 
 def test_raw_input_rst_severe(runner):
@@ -244,10 +244,10 @@ def test_raw_input_rst_severe(runner):
         raw_file = f.read()
     args = ["-t", "rst", "-r", raw_file]
     result = runner.invoke(main, args=args)
+    assert result.exit_code == 1
     assert result.output.startswith(
         'SEVERE: File "<raw_input>", line 3:\nTitle overline & underline mismatch.'
     )
-    assert result.exit_code == 1
 
 
 def test_raw_input_rst_warning(runner):
@@ -256,10 +256,10 @@ def test_raw_input_rst_warning(runner):
         raw_file = f.read()
     args = ["-t", "rst", "-r", raw_file]
     result = runner.invoke(main, args=args)
+    assert result.exit_code == 1
     assert result.output.startswith(
         'WARNING: File "<raw_input>", line 1:\nBullet list ends without a blank line; unexpected unindent.'
     )
-    assert result.exit_code == 1
 
 
 @pytest.mark.parametrize(
@@ -282,37 +282,37 @@ def test_raw_output(runner, file):
 def test_rst_error(runner):
     file = "tests/test_files/test_invalid_rst_error.rst"
     result = runner.invoke(main, args=[file])
+    assert result.exit_code == 1
     assert result.output.startswith(
         f'ERROR: File "{os.path.abspath(file)}", line 1:\nUnknown directive type "codeblock".'
     )
     assert result.output.endswith(
         "1 file were checked.\nDone, but 1 error occurred ❌💥❌\n"
     )
-    assert result.exit_code == 1
 
 
 def test_rst_severe(runner):
     file = "tests/test_files/test_invalid_rst_severe.rst"
     result = runner.invoke(main, args=[file])
+    assert result.exit_code == 1
     assert result.output.startswith(
         f'SEVERE: File "{os.path.abspath(file)}", line 3:\nTitle overline & underline mismatch.'
     )
     assert result.output.endswith(
         "1 file were checked.\nDone, but 1 error occurred ❌💥❌\n"
     )
-    assert result.exit_code == 1
 
 
 def test_rst_warning(runner):
     file = "tests/test_files/test_invalid_rst_warning.rst"
     result = runner.invoke(main, args=[file])
+    assert result.exit_code == 1
     assert result.output.startswith(
         f'WARNING: File "{os.path.abspath(file)}", line 1:\nBullet list ends without a blank line; unexpected unindent.'
     )
     assert result.output.endswith(
         "1 file were checked.\nDone, but 1 error occurred ❌💥❌\n"
     )
-    assert result.exit_code == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Make docstrfmt operate in parallel when processing more than 2 files similar to psf/black.
- Added a caching mechanism similar to psf/black has so files that haven't changed from the last run won't be checked again.