### PR TITLE
Switch from unmaintained appdirs to the drop-in replacement platformdirs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Change Log
 Unreleased
 ----------
 
+- Switch from unmaintained ``appdirs`` to the replacement ``platformdirs``.
+
 1.4.1 (2021/09/10)
 ------------------
 

--- a/docstrfmt/util.py
+++ b/docstrfmt/util.py
@@ -4,16 +4,16 @@ import tempfile
 from copy import copy
 from pathlib import Path
 
-from appdirs import user_cache_dir
 from docutils.parsers.rst.states import ParserError
 from docutils.utils import roman
+from platformdirs import user_cache_path
 
 from .const import __version__
 
 
 class FileCache:
     def __init__(self, context):
-        self.cache_dir = Path(user_cache_dir("docstrfmt", version=__version__))
+        self.cache_dir = user_cache_path("docstrfmt", version=__version__)
         self.context = context
         self.cache = self.read_cache()
 

--- a/setup.py
+++ b/setup.py
@@ -49,11 +49,11 @@ setup(
     },
     extras_require=extras_requires,
     install_requires=[
-        "appdirs",
         "black>=19.10b0",
         "click<8.0.0",
         "docutils",
         "libcst",
+        "platformdirs",
         "sphinx>=2.4.0",
         "tabulate",
         "toml",


### PR DESCRIPTION
I couldn't open an issue or search for code use since this is marked as a fork, so I cloned the repo and went straight for a PR; hope that's okay.

In any case, for some background, I'd observed a crash in the PRAW pre-commit suite that I discovered was fixed in #30 while working on the PR we've discussed to simplify and unify the PRAW linting situation, which ironically enough apparently initially went unnoticed due to that very issue (as otherwise the CIs would have immediately flagged the issue), the linting suite on the CIs and in the pre-push script having different versions and config then the pre-commit suite and not running in isolated envs (I'll pre-commit autoupdate to pull in the fixed version). 

Anyway, all that aside, given it was just added as a dep I wanted to let you know that appdirs is effectively [unmaintained](https://github.com/ActiveState/appdirs/issues/79) and [platformdirs](https://github.com/platformdirs/platformdirs) is the community's [drop-in replacement](https://github.com/platformdirs/platformdirs#why-this-fork).

Black, Pylint and other major projects have already switched, and given this dep was newly added, it would make sense to use the modern, maintained replacement now given its drop-in compatible and fixes numerous long-outstanding bugs with the original, instead of having to switch later when things eventually break. It also slightly simplifies the code, as `platformdirs` has native support for outputing `pathlib.Path`s.