### PR TITLE
Fix import error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change Log
 Unreleased
 ----------
 
+**Fixed**
+
+- Fix ``ImportError`` when importing from black. Pinned black to 22.8.*.
+
 1.5.0 (2022/07/19)
 ------------------
 

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -922,7 +922,13 @@ class Manager:
         self.docstring_trailing_line = docstring_trailing_line
 
     def _pre_process(self, node: docutils.nodes.Node, source: str) -> None:
-        """Do some node preprocessing that is generic across node types and is therefore most convenient to do as a simple recursive function rather than as part of the big dispatcher class."""
+        """Preprocess nodes.
+
+        This does some preprocessing to all nodes that is generic across node types and
+        is therefore most convenient to do as a simple recursive function rather than as
+        part of the big dispatcher class.
+
+        """
         # Strip all system_message nodes. (Just formatting them with no markup isn't enough, since that
         # could lead to extra spaces or empty lines between other elements.)
         errors = [

--- a/docstrfmt/rst_extras.py
+++ b/docstrfmt/rst_extras.py
@@ -1,4 +1,10 @@
-"""This module handles adding constructs to the reST parser in a way that makes sense for docstrfmt. Nonstandard directives and roles are inserted into the tree unparsed (wrapped in custom node classes defined here) so we can format them the way they came in without without caring about what they would normally expand to."""
+"""This module handles adding constructs to the reST parser in a way that makes sense for docstrfmt.
+
+Non-standard directives and roles are inserted into the tree unparsed (wrapped in custom
+node classes defined here) so we can format them the way they came in without without
+caring about what they would normally expand to.
+
+"""
 
 from typing import Any, Iterator, List, Tuple, Type, TypeVar
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     },
     extras_require=extras_requires,
     install_requires=[
-        "black==22.*",
+        "black==22.8.*",
         "click==8.*",
         "docutils==0.18.*",
         "libcst==0.4.*",


### PR DESCRIPTION
Fixes #47 

This removes the dependency on black's `cancel` and `shutdown` functions and instead implements them within `docstrfmt`.