### PR TITLE
Explicitly add code-block and highlight directives

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Unreleased
 
 **Added**
 
-- Added support for  in ``code-block`` directive.
+- Added support for in ``code-block`` directive.
 - Added support for ``highlight`` directive.
 
 1.6.1 (2023/12/12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change Log
 Unreleased
 ----------
 
+**Added**
+
+- Added support for  in ``code-block`` directive.
+- Added support for ``highlight`` directive.
+
 1.6.1 (2023/12/12)
 ------------------
 

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -702,7 +702,7 @@ class Formatters:
             yield f"[{node.attributes['refname']}]_"
 
     def inline(self, node: docutils.nodes.inline, context) -> inline_iterator:
-        yield from chain(self._format_children(node, context)) # pragma: no cover
+        yield from chain(self._format_children(node, context))  # pragma: no cover
 
     def label(self, node: docutils.nodes.footnote_reference, context):
         yield f"[{' '.join(chain(self._format_children(node, context)))}]"

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -18,6 +18,7 @@ from typing import (
 
 import black
 import docutils
+from attr import dataclass
 from blib2to3.pgen2.tokenize import TokenError
 from docutils.frontend import OptionParser
 from docutils.nodes import pending
@@ -116,24 +117,32 @@ word_info = namedtuple(
 )
 
 
+@dataclass
 class CodeFormatters:
-    @staticmethod
-    def python(code: str, context: FormatContext) -> str:
+    code: str
+    content_offset: int
+    context: FormatContext
+
+    def python(self) -> str:
         try:
-            code = black.format_str(code, mode=context.black_config).rstrip()
+            self.code = black.format_str(
+                self.code, mode=self.context.black_config
+            ).rstrip()
         except (UserWarning, black.InvalidInput, TokenError):
             try:
-                compile(code, context.current_file, mode="exec")
+                compile(self.code, "<code-block>", mode="exec")
             except SyntaxError as syntax_error:
-                context.manager.error_count += 1
-                current_line = get_code_line(context.current_file, code, strict=True)
-                if context.manager.reporter:
-                    context.manager.reporter.error(
+                self.context.manager.error_count += 1
+                document_line = get_code_line(
+                    self.context.current_file, self.code, True
+                ) - len(self.code.splitlines())
+                if self.context.manager.reporter:
+                    self.context.manager.reporter.error(
                         f"SyntaxError: {syntax_error.msg}:\n\nFile"
-                        f' "{context.current_file}", line'
-                        f' {current_line}:\n{syntax_error.text}{" " * (syntax_error.offset - 1)}^'
+                        f' "{self.context.current_file}", line'
+                        f' {document_line + syntax_error.lineno}:\n{syntax_error.text}\n{" " * (syntax_error.offset - 1)}^'
                     )
-        return code
+        return self.code
 
 
 class Formatters:
@@ -409,22 +418,44 @@ class Formatters:
     def directive(self, node: docutils.nodes.Node, context) -> line_iterator:
         directive = node.attributes["directive"]
 
-        yield " ".join([f".. {directive.name}::", *directive.arguments])
+        is_code_block = directive.name in ["code", "code-block"]
+
+        yield " ".join(
+            [
+                f".. {'code-block' if is_code_block else directive.name}::",
+                *directive.arguments,
+            ]
+        )
         # Just rely on the order being stable, hopefully.
         for k, v in directive.options.items():
             yield f"    :{k}:" if v is None else f"    :{k}: {v}"
 
-        if directive.raw:
-            yield from self._prepend_if_any("", self._with_spaces(4, directive.content))
-        else:
-            sub_doc = self.manager.parse_string(
-                context.current_file, "\n".join(directive.content)
-            )
-            if sub_doc.children:
-                yield ""
-                yield from self._with_spaces(
-                    4, self.manager.perform_format(sub_doc, context.indent(4))
+        if is_code_block:
+            language = directive.arguments[0] if directive.arguments else None
+            text = "\n".join(directive.content.data)
+            try:
+                func = getattr(
+                    CodeFormatters(text, directive.content_offset, context), language
                 )
+                text = func()
+            except (AttributeError, TypeError):
+                pass
+            yield ""
+            yield from self._with_spaces(4, text.splitlines())
+        else:
+            if directive.raw:
+                yield from self._prepend_if_any(
+                    "", self._with_spaces(4, directive.content)
+                )
+            else:
+                sub_doc = self.manager.parse_string(
+                    context.current_file, "\n".join(directive.content)
+                )
+                if sub_doc.children:
+                    yield ""
+                    yield from self._with_spaces(
+                        4, self.manager.perform_format(sub_doc, context.indent(4))
+                    )
 
     def document(self, node: docutils.nodes.document, context) -> line_iterator:
         yield from self._chain_with_line_separator(
@@ -671,7 +702,7 @@ class Formatters:
             yield f"[{node.attributes['refname']}]_"
 
     def inline(self, node: docutils.nodes.inline, context) -> inline_iterator:
-        yield from chain(self._format_children(node, context))
+        yield from chain(self._format_children(node, context)) # pragma: no cover
 
     def label(self, node: docutils.nodes.footnote_reference, context):
         yield f"[{' '.join(chain(self._format_children(node, context)))}]"
@@ -723,22 +754,10 @@ class Formatters:
     def literal_block(
         self, node: docutils.nodes.literal_block, context: FormatContext
     ) -> line_iterator:
-        languages = [
-            class_type
-            for class_type in node.attributes["classes"]
-            if class_type != "code"
-        ]
-        language = languages[0] if languages else None
-        yield f".. code-block::{f' {language}' if language else ''}"
-        yield ""
-        text = "".join(chain(self._format_children(node, context)))
-
-        try:
-            func = getattr(CodeFormatters(), language)
-            text = func(text, context)
-        except (AttributeError, TypeError):
-            pass
-        yield from self._with_spaces(4, text.splitlines())
+        yield "::"
+        yield from self._prepend_if_any(
+            "", self._with_spaces(4, node.rawsource.splitlines())
+        )
 
     def paragraph(
         self, node: docutils.nodes.paragraph, context: FormatContext

--- a/docstrfmt/rst_extras.py
+++ b/docstrfmt/rst_extras.py
@@ -133,9 +133,11 @@ def register() -> None:
 
     # sphinx directives
     _add_directive("autosummary", autosummary.Autosummary)
+    _add_directive("code-block", code.CodeBlock)
     _add_directive("currentmodule", PyCurrentModule)
     _add_directive("deprecated", other.VersionChange, raw=False)
     _add_directive("function", PyFunction)
+    _add_directive("highlight", code.Highlight)
     _add_directive("literalinclude", code.LiteralInclude)
     _add_directive("py:function", PyFunction)
     _add_directive("rst-class", other.Class)

--- a/sample.rst
+++ b/sample.rst
@@ -109,6 +109,9 @@ Python code blocks are formatted with Black_ and Go ones with gofmt_ (if it's fo
 ``PATH``).
 
 .. code-block:: python
+    :caption: An example of code-block options
+    :linenos:
+    :emphasize-lines: 2,4,5
 
     x = [
         "here are some items",

--- a/tests/test_files/test_file.rst
+++ b/tests/test_files/test_file.rst
@@ -254,6 +254,35 @@ Results in:
     This is preformatted text, and the
     last "::" paragraph is removed
 
+Code blocks can have additional options to add a caption, insert line 
+numbers, emphasize specific lines, and more. 
+
+.. code-block::
+
+    .. code-block:: python
+        :caption: An example of code-block options
+        :linenos:
+        :emphasize-lines: 2,4,5
+
+        @pytest.fixture
+        def date_input():
+            now = datetime.datetime.now()
+            current_date_string = f"{now.year}-{now.month}-{now.day}"
+            return current_date_string
+
+Results in: 
+
+.. code-block:: python
+    :caption: An example of code-block options
+    :linenos:
+    :emphasize-lines: 2,4,5
+
+    @pytest.fixture
+    def date_input():
+        now = datetime.datetime.now()
+        current_date_string = f"{now.year}-{now.month}-{now.day}"
+        return current_date_string
+
 Python code blocks are formatted with Black_ (if it's found on ``PATH``).
 
 .. code-block:: python
@@ -267,6 +296,87 @@ Python code blocks are formatted with Black_ (if it's found on ``PATH``).
 .. code-block:: text
 
     this is just text
+
+You can also control code highlighting. The default mode is to 
+highlight Python code but don't give an error if a language is
+not recognized: 
+
+Some Python code:
+
+::
+
+   def main():
+      print("Hello, world!")
+
+Followed by some C code
+
+::
+
+   void main() {
+      printf("Hello, world!");
+   }
+
+----------
+
+If we insert the directive:
+
+.. code-block::
+
+    .. highlight:: C
+
+Then C code will be highlighted. 
+    
+.. highlight:: C
+
+Some Python code:
+
+::
+
+   def main():
+      print("Hello, world!")
+
+Followed by some C code
+
+::
+
+   void main() {
+      printf("Hello, world!");
+   }
+
+----------
+
+You can also turn off code highlighting completely by using ``none``:
+
+.. code-block::
+
+    .. highlight:: none
+
+.. highlight:: none
+
+Some Python code:
+
+::
+
+   def main():
+      print("Hello, world!")
+
+Followed by some C code
+
+::
+
+   void main() {
+      printf("Hello, world!");
+   }
+
+----------
+
+And then go back to default highlighting (Python with silent failures). 
+
+.. code-block::
+
+    .. highlight:: default
+
+.. highlight:: default
 
 .. admonition:: title a b
 

--- a/tests/test_files/test_file.rst
+++ b/tests/test_files/test_file.rst
@@ -254,8 +254,8 @@ Results in:
     This is preformatted text, and the
     last "::" paragraph is removed
 
-Code blocks can have additional options to add a caption, insert line 
-numbers, emphasize specific lines, and more. 
+Code blocks can have additional options to add a caption, insert line numbers, emphasize
+specific lines, and more.
 
 .. code-block::
 
@@ -270,7 +270,7 @@ numbers, emphasize specific lines, and more.
             current_date_string = f"{now.year}-{now.month}-{now.day}"
             return current_date_string
 
-Results in: 
+Results in:
 
 .. code-block:: python
     :caption: An example of code-block options
@@ -297,26 +297,25 @@ Python code blocks are formatted with Black_ (if it's found on ``PATH``).
 
     this is just text
 
-You can also control code highlighting. The default mode is to 
-highlight Python code but don't give an error if a language is
-not recognized: 
+You can also control code highlighting. The default mode is to highlight Python code but
+don't give an error if a language is not recognized:
 
 Some Python code:
 
 ::
 
-   def main():
-      print("Hello, world!")
+    def main():
+       print("Hello, world!")
 
 Followed by some C code
 
 ::
 
-   void main() {
-      printf("Hello, world!");
-   }
+    void main() {
+       printf("Hello, world!");
+    }
 
-----------
+----
 
 If we insert the directive:
 
@@ -324,26 +323,26 @@ If we insert the directive:
 
     .. highlight:: C
 
-Then C code will be highlighted. 
-    
+Then C code will be highlighted.
+
 .. highlight:: C
 
 Some Python code:
 
 ::
 
-   def main():
-      print("Hello, world!")
+    def main():
+       print("Hello, world!")
 
 Followed by some C code
 
 ::
 
-   void main() {
-      printf("Hello, world!");
-   }
+    void main() {
+       printf("Hello, world!");
+    }
 
-----------
+----
 
 You can also turn off code highlighting completely by using ``none``:
 
@@ -357,20 +356,20 @@ Some Python code:
 
 ::
 
-   def main():
-      print("Hello, world!")
+    def main():
+       print("Hello, world!")
 
 Followed by some C code
 
 ::
 
-   void main() {
-      printf("Hello, world!");
-   }
+    void main() {
+       printf("Hello, world!");
+    }
 
-----------
+----
 
-And then go back to default highlighting (Python with silent failures). 
+And then go back to default highlighting (Python with silent failures).
 
 .. code-block::
 
@@ -499,7 +498,7 @@ To indicate the document title in reStructuredText, use a unique adornment style
 beginning of the document. To indicate the document subtitle, use another unique
 adornment style immediately after the document title. For example:
 
-.. code-block::
+::
 
     ================
      Document Title


### PR DESCRIPTION
When I tried to use the following: 

```
.. code-block:: python
    :caption: conftest.py

    @pytest.fixture
    def fixture_1():
        return 5
```

I got the following error: 

```
Error in "code-block" directive:
unknown option: "caption".
```

Adding in an explicit reference to `code.CodeBlock` made it work as expected, and I threw in `code.Highlight` as well although I didn't test it. 