### PR TITLE
Updated black, but be liberal in the dependency setting

### DIFF
--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -196,9 +196,11 @@ class Formatters:
         self, node: docutils.nodes.Node, context
     ) -> Iterator[Iterator[str]]:
         return (
-            self.manager.perform_format(child, context)
-            if index == 0
-            else self.manager.perform_format(child, context.wrap_first_at(0))
+            (
+                self.manager.perform_format(child, context)
+                if index == 0
+                else self.manager.perform_format(child, context.wrap_first_at(0))
+            )
             for index, child in enumerate(node.children)
         )
 
@@ -893,8 +895,8 @@ class Formatters:
                 None, chain(self._format_children(node, context)), context, node.line
             )
         )
-        anonymous_suffix: Callable[[bool], str] = (
-            lambda anonymous: "__" if anonymous else "_"
+        anonymous_suffix: Callable[[bool], str] = lambda anonymous: (
+            "__" if anonymous else "_"
         )
         attributes = node.attributes  # type: ignore
         children = node.children  # type: ignore

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -326,8 +326,8 @@ def _format_file(
         raw_output = True
     reporter.print(f"Checking {file}", 2)
     misformatted = False
-    with nullcontext(sys.stdin) if file.name == "-" else open(
-        file, encoding="utf-8"
+    with (
+        nullcontext(sys.stdin) if file.name == "-" else open(file, encoding="utf-8")
     ) as f:
         input_string = f.read()
         newline = getattr(f, "newlines", None)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     },
     extras_require=extras_requires,
     install_requires=[
-        "black==23.*",
+        "black==24.*",
         "click==8.*",
         "docutils==0.20.*",
         "libcst==1.*",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 """docstrfmt Test Suite."""
+
 import black
 import docutils.nodes
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Prepare py.test."""
+
 import os
 import shutil
 

--- a/tests/test_files/error_files/py_file_error_bad_codeblock.py
+++ b/tests/test_files/error_files/py_file_error_bad_codeblock.py
@@ -1,6 +1,5 @@
 """This is an example python file"""
 
-
 test = "value"
 
 

--- a/tests/test_files/error_files/py_file_error_empty_returns.py
+++ b/tests/test_files/error_files/py_file_error_empty_returns.py
@@ -1,6 +1,5 @@
 """This is an example python file"""
 
-
 test = "value"
 
 

--- a/tests/test_files/error_files/py_file_error_invalid_rst.py
+++ b/tests/test_files/error_files/py_file_error_invalid_rst.py
@@ -1,6 +1,5 @@
 """This is an example python file"""
 
-
 test = "value"
 
 

--- a/tests/test_files/py_file.py
+++ b/tests/test_files/py_file.py
@@ -1,6 +1,5 @@
 """This is an example python file"""
 
-
 test = "value"
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -143,7 +143,7 @@ def test_invalid_blank_return_py(runner):
     result = runner.invoke(main, args=[file])
     assert result.exit_code == 1
     assert result.output.startswith(
-        f'InvalidRstError: ERROR: File "{os.path.abspath(file)}", line 67:\nEmpty'
+        f'InvalidRstError: ERROR: File "{os.path.abspath(file)}", line 66:\nEmpty'
         " `:returns:` field. Please add a field body or omit completely."
     )
     assert result.output.endswith(
@@ -213,7 +213,7 @@ def test_invalid_code_block_py(runner):
     else:
         error = "SyntaxError: EOL while scanning string literal"
     assert result.output.startswith(
-        f'{error}:\n\nFile "{os.path.abspath(file)}", line 44:'
+        f'{error}:\n\nFile "{os.path.abspath(file)}", line 43:'
     )
     assert result.output.endswith(
         "1 file were checked.\nDone, but 2 errors occurred ❌💥❌\n"


### PR DESCRIPTION
Projects implementing docstrfmt may already be relying on the black formatter, therfeore we should try as much as possible to not interfere with their dependency. Ideally we should support the most recent version of black, but allow for a wider range.