### PR TITLE
Support for running with the -m option

### DIFF
--- a/docstrfmt/__main__.py
+++ b/docstrfmt/__main__.py
@@ -1,0 +1,3 @@
+from docstrfmt.main import main
+
+main()


### PR DESCRIPTION
When I run docstrfmt with the -m option:
```sh
./venv/bin/python -m docstrfmt
```
I get the error: 
```
No module named docstrfmt.__main__; 'docstrfmt' is a package and cannot be directly executed`
```
To solve this problem, I have added `__main__.py` in the same way as other libraries.

Reference:
- https://stackoverflow.com/questions/22241420/execution-of-python-code-with-m-option-or-not
- https://github.com/PyCQA/isort/blob/main/isort/__main__.py