### PR TITLE
Retain literal code block with args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Unreleased
 **Fixed**
 
 - Line length is now correctly resolved. Previously, it was always set to 88.
+- Fix handling of ``.. code::`` blocks. They should now be correctly formatted to ``..
+  code-block::``.
 
 1.8.0 (2024/07/28)
 ------------------

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -837,10 +837,10 @@ class Formatters:
     def literal_block(
         self, node: docutils.nodes.literal_block, context: FormatContext
     ) -> line_iterator:
-        if (
-            len(node.attributes["classes"]) > 1
-            and node.attributes["classes"][0] in ["code", "code-block"]
-        ):
+        if len(node.attributes["classes"]) > 1 and node.attributes["classes"][0] in [
+            "code",
+            "code-block",
+        ]:
             args = "".join([f" {arg}" for arg in node.attributes["classes"][1:]])
             yield f".. code-block::{args}"
         else:

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -842,7 +842,7 @@ class Formatters:
             and node.attributes["classes"][0] == "code"
         ):
             args = "".join([f" {arg}" for arg in node.attributes["classes"][1:]])
-            yield f".. code::{args}"
+            yield f".. code-block::{args}"
         else:
             yield "::"
         yield from self._prepend_if_any(

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -837,7 +837,14 @@ class Formatters:
     def literal_block(
         self, node: docutils.nodes.literal_block, context: FormatContext
     ) -> line_iterator:
-        yield "::"
+        if (
+            len(node.attributes["classes"]) > 1
+            and node.attributes["classes"][0] == "code"
+        ):
+            args = "".join([f" {arg}" for arg in node.attributes["classes"][1:]])
+            yield f".. code::{args}"
+        else:
+            yield "::"
         yield from self._prepend_if_any(
             "", self._with_spaces(4, node.rawsource.splitlines())
         )

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -839,7 +839,7 @@ class Formatters:
     ) -> line_iterator:
         if (
             len(node.attributes["classes"]) > 1
-            and node.attributes["classes"][0] == "code"
+            and node.attributes["classes"][0] in ["code", "code-block"]
         ):
             args = "".join([f" {arg}" for arg in node.attributes["classes"][1:]])
             yield f".. code-block::{args}"

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -141,7 +141,6 @@ word_info = namedtuple(
 @dataclass
 class CodeFormatters:
     code: str
-    content_offset: int
     context: FormatContext
 
     def python(self) -> str:
@@ -474,9 +473,7 @@ class Formatters:
             language = directive.arguments[0] if directive.arguments else None
             text = "\n".join(directive.content.data)
             try:
-                func = getattr(
-                    CodeFormatters(text, directive.content_offset, context), language
-                )
+                func = getattr(CodeFormatters(text, context), language)
                 text = func()
             except (AttributeError, TypeError):
                 pass
@@ -843,6 +840,16 @@ class Formatters:
         ]:
             args = "".join([f" {arg}" for arg in node.attributes["classes"][1:]])
             yield f".. code-block::{args}"
+            language = node.attributes["classes"][1]
+            text = node.rawsource
+            try:
+                func = getattr(CodeFormatters(text, context), language)
+                text = func()
+            except (AttributeError, TypeError):
+                pass
+            yield ""
+            yield from self._with_spaces(4, text.splitlines())
+            return
         else:
             yield "::"
         yield from self._prepend_if_any(

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -1,11 +1,11 @@
 import asyncio
-import contextlib
 import glob
 import logging
 import os
 import signal
 import sys
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from contextlib import nullcontext
 from copy import copy
 from functools import partial
 from multiprocessing import Manager as MultiManager
@@ -94,18 +94,6 @@ def shutdown(loop: asyncio.AbstractEventLoop) -> None:  # pragma: no cover
         cf_logger = logging.getLogger("concurrent.futures")
         cf_logger.setLevel(logging.CRITICAL)
         loop.close()
-
-
-# Define this here to support Python <3.7.
-class nullcontext(contextlib.AbstractContextManager):  # type: ignore
-    def __init__(self, enter_result: Any = None):
-        self.enter_result = enter_result
-
-    def __enter__(self) -> Any:
-        return self.enter_result
-
-    def __exit__(self, *excinfo: Any) -> Any:
-        pass
 
 
 class Reporter:

--- a/docstrfmt/util.py
+++ b/docstrfmt/util.py
@@ -1,6 +1,8 @@
 import os
 import pickle
+import sys
 import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 
 from docutils.parsers.rst.states import ParserError
@@ -72,7 +74,11 @@ class FileCache:
 
 
 def get_code_line(current_file, code, strict=False):
-    with open(current_file, encoding="utf-8") as f:
+    with (
+        nullcontext(sys.stdin)
+        if current_file.name == "-"
+        else open(current_file, encoding="utf-8")
+    ) as f:
         source = f.read()
     lines = source.splitlines()
     code_lines = code.splitlines()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,14 +110,22 @@ def test_encoding_stdin(runner):
 
 
 @pytest.mark.parametrize(
-    "blocktype", ["::", ".. block::", ".. code-block::", ".. code-block:: java"]
+    "block_type,expected_block_type",
+    [
+        ("::", "::"),
+        (".. code:: sh", ".. code-block:: sh"),
+        (".. code:: python", ".. code-block:: python"),
+        (".. code-block::", ".. code-block::"),
+        (".. code-block:: java", ".. code-block:: java"),
+    ],
 )
-def test_code_block_argless(runner, blocktype):
-    file = f"{blocktype}\n\n    A"
+def test_code_to_codeblock(runner, block_type, expected_block_type):
+    file = f"{block_type}\n\n    name = ''"
     args = ["-"]
     result = runner.invoke(main, args=args, input=file)
     assert result.exit_code == 0
-    assert result.output == f"{blocktype}\n\n    A\n"
+    name_value = '""' if "python" in file else "''"
+    assert result.output == f"{expected_block_type}\n\n    name = {name_value}\n"
 
 
 def test_exclude(runner):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -109,6 +109,17 @@ def test_encoding_stdin(runner):
     assert result.output == file
 
 
+@pytest.mark.parametrize("blocktype", [
+    "::", ".. block::", ".. code-block::", ".. code-block:: java"
+])
+def test_code_block_argless(runner, blocktype):
+    file = f"{blocktype}\n\n    A"""
+    args = ["-"]
+    result = runner.invoke(main, args=args, input=file)
+    assert result.exit_code == 0
+    assert result.output == f"{blocktype}\n\n    A\n"
+
+
 def test_exclude(runner):
     args = [
         "-e",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -109,11 +109,11 @@ def test_encoding_stdin(runner):
     assert result.output == file
 
 
-@pytest.mark.parametrize("blocktype", [
-    "::", ".. block::", ".. code-block::", ".. code-block:: java"
-])
+@pytest.mark.parametrize(
+    "blocktype", ["::", ".. block::", ".. code-block::", ".. code-block:: java"]
+)
 def test_code_block_argless(runner, blocktype):
-    file = f"{blocktype}\n\n    A"""
+    file = f"{blocktype}\n\n    A"
     args = ["-"]
     result = runner.invoke(main, args=args, input=file)
     assert result.exit_code == 0


### PR DESCRIPTION
Solves #79 

Assuming literal block has classes attributes (more than the first indicating that it is a code block), format it as `.. code:: {args}` instead of `::`.