### PR TITLE
Fix line length resolution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Unreleased
 
 - Relaxed sphinx dependency.
 
+**Fixed**
+
+- Line length is now correctly resolved. Previously, it was always set to 88.
+
 1.8.0 (2024/07/28)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -73,8 +73,22 @@ Usage
     # Format the given files, printing all output to stdout.
     docstrfmt -o <file>...
 
-    # Wrap paragraphs to the given line length where possible (default 88).
+    # Wrap paragraphs to the given line length where possible (default to whatever is
+    # set for black).
+
     docstrfmt -l <length>
+
+.. note::
+
+    Line length is resolved in the following order:
+
+    1. The length specified with the ``-l`` flag.
+    2. The ``line-length`` specified in the ``tool.docstrfmt`` section in
+       ``pyproject.toml``.
+    3. The ``line-length`` specified in the ``tool.black`` section in
+       ``pyproject.toml``.
+    4. The default line length of black's default line length (88 at the time of this
+       writing).
 
 Like Black's blackd_, there is also a daemon that provides formatting via HTTP requests
 to avoid the cost of starting and importing everything on every run.
@@ -93,14 +107,14 @@ to avoid the cost of starting and importing everything on every run.
     # Print the formatted version of a file.
     curl http://locahost:5219 --data-binary @<file>
 
-    # Specify the line length (default 88).
+    # Specify the line length (default to whatever is set for black).
     curl -H 'X-Line-Length: 72' http://locahost:5219 --data-binary @<file>
 
     # Mimic the standalone tool: read from stdin, write to stdout, exit with
     # a nonzero status code if there are errors.
     curl -fsS http://locahost:5219 --data-binary @/dev/stdin
 
-With editors
+With Editors
 ~~~~~~~~~~~~
 
 PyCharm

--- a/docstrfmt/server.py
+++ b/docstrfmt/server.py
@@ -4,6 +4,7 @@ import time
 import click
 import docutils
 from aiohttp import web
+from black import DEFAULT_LINE_LENGTH
 
 from . import Manager, rst_extras
 
@@ -16,7 +17,7 @@ rst_extras.register()
 
 
 async def handler(request) -> web.Response:
-    width = int(request.headers.get("X-Line-Length", 88))
+    width = int(request.headers.get("X-Line-Length", DEFAULT_LINE_LENGTH))
     body = await request.text()
 
     start_time = time.perf_counter()

--- a/tests/test_files/pyproject-line-length_black+docstrfmt.toml
+++ b/tests/test_files/pyproject-line-length_black+docstrfmt.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 123
+target_version = ['PY37']
+
+[tool.docstrfmt]
+files = [ 'tests/test_files/test_file.rst' ]
+line-length = 124

--- a/tests/test_files/pyproject-line-length_black.toml
+++ b/tests/test_files/pyproject-line-length_black.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 123
+target_version = ['PY37']
+
+[tool.docstrfmt]
+files = [ 'tests/test_files/test_file.rst' ]

--- a/tests/test_files/pyproject-line-length_docstrfmt.toml
+++ b/tests/test_files/pyproject-line-length_docstrfmt.toml
@@ -1,0 +1,6 @@
+[tool.black]
+target_version = ['PY37']
+
+[tool.docstrfmt]
+files = [ 'tests/test_files/test_file.rst' ]
+line-length = 124

--- a/tests/test_files/pyproject-line-length_none.toml
+++ b/tests/test_files/pyproject-line-length_none.toml
@@ -1,0 +1,5 @@
+[tool.black]
+target_version = ['PY37']
+
+[tool.docstrfmt]
+files = [ 'tests/test_files/test_file.rst' ]


### PR DESCRIPTION
Fixes #85 

Line length is now correctly resolved. It is now resolved in the following order:

1. The length specified with the ``-l`` flag.
2. The ``line-length`` specified in the ``tool.docstrfmt`` section in ``pyproject.toml``.
3. The ``line-length`` specified in the ``tool.black`` section in ``pyproject.toml``.
4. The default line length of black's default line length.