### PR TITLE
Add additional line length resolution information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Usage
 
     1. The length specified with the ``-l`` flag.
     2. The ``line-length`` specified in the ``tool.docstrfmt`` section in the file
-       specified with``--pyproject-config``.
+       specified with ``--pyproject-config``.
     3. The ``line-length`` specified in the ``tool.black`` section in the file specified
        with ``--pyproject-config``.
     4. The ``line-length`` specified in the ``tool.docstrfmt`` section in a

--- a/README.rst
+++ b/README.rst
@@ -84,15 +84,14 @@ Usage
 
     1. The length specified with the ``-l`` flag.
     2. The ``line-length`` specified in the ``tool.docstrfmt`` section in the file
-       specified with ``-p`` or ``--pyproject-config``.
+       specified with``--pyproject-config``.
     3. The ``line-length`` specified in the ``tool.black`` section in the file specified
-       with ``-p`` or ``--pyproject-config``.
+       with ``--pyproject-config``.
     4. The ``line-length`` specified in the ``tool.docstrfmt`` section in a
        ``pyproject.toml`` autodetected `like Black`_.
     5. The ``line-length`` specified in the ``tool.black`` section in a
        ``pyproject.toml`` autodetected `like Black`_.
-    6. The default line length of `Black's default line length`_ (88 at the time of this
-       writing).
+    6. `Black's default line length`_ (88 at the time of this writing).
 
 Like Black's blackd_, there is also a daemon that provides formatting via HTTP requests
 to avoid the cost of starting and importing everything on every run.

--- a/README.rst
+++ b/README.rst
@@ -83,15 +83,15 @@ Usage
     Line length is resolved in the following order:
 
     1. The length specified with the ``-l`` flag.
-    2. The ``line-length`` specified in the ``tool.docstrfmt`` section in
-       the file specified with ``-p`` or ``--pyproject-config``.
-    3. The ``line-length`` specified in the ``tool.black`` section in
-       the file specified with ``-p`` or ``--pyproject-config``.
-    4. The ``line-length`` specified in the ``tool.docstrfmt`` section in
-       the ``pyproject.toml`` of the current project.
-    5. The ``line-length`` specified in the ``tool.black`` section in
-       the ``pyproject.toml`` of the current project.
-    6. The default line length of black's default line length (88 at the time of this
+    2. The ``line-length`` specified in the ``tool.docstrfmt`` section in the file
+       specified with ``-p`` or ``--pyproject-config``.
+    3. The ``line-length`` specified in the ``tool.black`` section in the file specified
+       with ``-p`` or ``--pyproject-config``.
+    4. The ``line-length`` specified in the ``tool.docstrfmt`` section in a
+       ``pyproject.toml`` autodetected `like Black`_.
+    5. The ``line-length`` specified in the ``tool.black`` section in a
+       ``pyproject.toml`` autodetected `like Black`_.
+    6. The default line length of `Black's default line length`_ (88 at the time of this
        writing).
 
 Like Black's blackd_, there is also a daemon that provides formatting via HTTP requests
@@ -209,9 +209,13 @@ With pre-commit
 
 .. _black: https://github.com/psf/black
 
+.. _black's default line length: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length
+
 .. _blackd: https://github.com/psf/black#blackd
 
 .. _docutils: https://docutils.sourceforge.io/
+
+.. _like black: https://ichard26-testblackdocs.readthedocs.io/en/refactor_docs/pyproject_toml.html#where-black-looks-for-the-file
 
 .. _pandoc: https://pandoc.org/
 

--- a/README.rst
+++ b/README.rst
@@ -84,10 +84,14 @@ Usage
 
     1. The length specified with the ``-l`` flag.
     2. The ``line-length`` specified in the ``tool.docstrfmt`` section in
-       ``pyproject.toml``.
+       the file specified with ``-p`` or ``--pyproject-config``.
     3. The ``line-length`` specified in the ``tool.black`` section in
-       ``pyproject.toml``.
-    4. The default line length of black's default line length (88 at the time of this
+       the file specified with ``-p`` or ``--pyproject-config``.
+    4. The ``line-length`` specified in the ``tool.docstrfmt`` section in
+       the ``pyproject.toml`` of the current project.
+    5. The ``line-length`` specified in the ``tool.black`` section in
+       the ``pyproject.toml`` of the current project.
+    6. The default line length of black's default line length (88 at the time of this
        writing).
 
 Like Black's blackd_, there is also a daemon that provides formatting via HTTP requests


### PR DESCRIPTION
## Description

I was tinkering with the tool configs for a project and realized that I wasn't sure if `docstrfmt <file>` with no arguments would pull from my pyproject.toml file. I learned that it did, so this PR helps clarify the line length resolution more, from `-l` -> `-p` -> project `pyproject.toml` -> black default, as well as what the auto-detection method is for finding a relevant pyproject.toml file.

## Todos/Questions

- [ ] Please double check that the auto-detect information I added is correct.
- [ ] Let me know if I should do the hyperlinks a different way. I wasn't sure and found examples of both, so I chose the one that would read better if you are looking at the raw text file.