### PR TITLE
Add `meta` directive support

### DIFF
--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -573,6 +573,7 @@ class Formatters:
     error = _sub_admonition
     hint = _sub_admonition
     important = _sub_admonition
+    meta = _sub_admonition
     note = _sub_admonition
     seealso = _sub_admonition
     tip = _sub_admonition

--- a/docstrfmt/rst_extras.py
+++ b/docstrfmt/rst_extras.py
@@ -108,6 +108,7 @@ def register() -> None:
     _add_directive("rst-table", tables.RSTTable, raw=False)
     _add_directive("rst-class", misc.Class)
     _add_directive("math", body.MathBlock)
+    _add_directive("meta", misc.Meta)
     _add_directive("raw", misc.Raw)
 
     # sphinx directives

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "black==24.*",
   "click==8.*",
   "docutils==0.20.*",
-  "libcst==1.4.0",
+  "libcst==1.*",
   "platformdirs==4.*",
   "sphinx>=7,<9",
   "tabulate==0.9.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "black==24.*",
   "click==8.*",
   "docutils==0.20.*",
-  "libcst==1.*",
+  "libcst==1.4.0",
   "platformdirs==4.*",
   "sphinx>=7,<9",
   "tabulate==0.9.*",

--- a/tests/test_files/test_file.rst
+++ b/tests/test_files/test_file.rst
@@ -1,6 +1,6 @@
 .. meta::
-   :description: Simple file to test the formatting.
-   :keywords: rSt, formatter, test
+    :description: Simple file to test the formatting.
+    :keywords: rSt, formatter, test
 
 A ReStructuredText Primer
 =========================

--- a/tests/test_files/test_file.rst
+++ b/tests/test_files/test_file.rst
@@ -1,5 +1,6 @@
 .. meta::
-    :description: Simple file to test the formatting.
+   :description: Simple file to test the formatting.
+   :keywords: rSt, formatter, test
 
 A ReStructuredText Primer
 =========================

--- a/tests/test_files/test_file.rst
+++ b/tests/test_files/test_file.rst
@@ -1,3 +1,6 @@
+.. meta::
+    :description: Simple file to test the formatting.
+
 A ReStructuredText Primer
 =========================
 

--- a/tests/test_files/test_file.txt
+++ b/tests/test_files/test_file.txt
@@ -1,5 +1,6 @@
 .. meta::
-    :description: Simple file to test the formatting.
+   :description: Simple file to test the formatting.
+   :keywords: rSt, formatter, test
 
 A ReStructuredText Primer
 =========================

--- a/tests/test_files/test_file.txt
+++ b/tests/test_files/test_file.txt
@@ -1,3 +1,6 @@
+.. meta::
+    :description: Simple file to test the formatting.
+
 A ReStructuredText Primer
 =========================
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -540,7 +540,11 @@ def test_raw_output(runner, file):
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     if file.endswith("rst"):
-        assert result.output.startswith("A ReStructuredText Primer")
+        assert result.output.startswith(
+            ".. meta::\n"
+            "    :description: Simple file to test the formatting.\n"
+            "    :keywords: rSt, formatter, test\n\nA ReStructuredText Primer"
+        )
     elif file.endswith("py"):
         assert result.output.startswith('"""This is an example python file"""')
     output = result.output


### PR DESCRIPTION
As mentioned in #96, there is currently no support for the `meta` `docutils` directive (https://docutils.sourceforge.io/docs/ref/rst/directives.html#metadata). This simple PR adds it.