### PR TITLE
Preserve single line comments into the same line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 
 - Relaxed pins from dependencies, keeping only the lower pins. This allows docstrfmt to
   be installed alongside other packages more easily.
+- Comment blocks that do not contain new-line characters are now kept on a single output
+  line.
 
 **Removed**
 

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -623,6 +623,12 @@ class Formatters:
     def comment(
         self, node: docutils.nodes.comment, context: FormatContext
     ) -> line_iterator:
+        if len(node.children) == 1:
+            text = "\n".join(chain(self._format_children(node, context)))
+            if "\n" not in text:
+                yield f".. {text}"
+                return
+
         yield ".."
         if node.children:
             text = "\n".join(chain(self._format_children(node, context)))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -708,12 +708,8 @@ def test_globbing(runner, file):
 
 
 def test_comment_preserve_single_line(runner):
-    file = (
-        "..  A comment in a single line is not placed on the next one.\n"
-    )
-    fixed = (
-        ".. A comment in a single line is not placed on the next one.\n"
-    )
+    file = "..  A comment in a single line is not placed on the next one.\n"
+    fixed = ".. A comment in a single line is not placed on the next one.\n"
     args = ["-r", file]
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -705,3 +705,16 @@ def test_globbing(runner, file):
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     assert result.output.endswith("were reformatted.\nDone! 🎉\n")
+
+
+def test_comment_preserve_single_line(runner):
+    file = (
+        "..  A comment in a single line is not placed on the next one.\n"
+    )
+    fixed = (
+        ".. A comment in a single line is not placed on the next one.\n"
+    )
+    args = ["-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == fixed


### PR DESCRIPTION
This PR resolves issue #110 by slightly modifying the behaviour of docstrfmt when comment blocks do not contain themselves newlines:

```rst
.. this is a comment
```

Used to be formatted as:

```rst
..
    this is a comment
```

Whereas now it will be formatted as:

```rst
.. this is a comment
```

Multiline comments are unaffected.  So:

```rst
.. this is a multi-line comment
   this is the second line of the comment
```

The output will continue to be:

```rst
..
    this is a multi-line comment
    this is the second line of the comment
```

A test unit was added to check for this formatting rule under these conditions.