### PR TITLE
Closes #91 by implementing configurable section header adornments.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 **Added**
 
 - Added support for Python 3.13.
+- Added command-line option (-s) to control whether to format section headers, and
+  optionally how.
 
 **Changed**
 
@@ -14,6 +16,9 @@ Unreleased
   be installed alongside other packages more easily.
 - Comment blocks that do not contain new-line characters are now kept on a single output
   line.
+- By default, do not change section adornments defined by the user.
+- Changed default section heading adornments to match the ones described at
+  https://devguide.python.org/documentation/markup/#sections.
 
 **Removed**
 

--- a/docstrfmt/const.py
+++ b/docstrfmt/const.py
@@ -18,7 +18,11 @@ DEFAULT_EXCLUDE = [
     "**/build",
     "**/dist",
 ]
-SECTION_CHARS = "=-~+.'\"`^_*:#"
+# Part/Chapter/Section adornment characters. The special `|` character separated
+# sections without overlines. If that is not present, then we consider all sections to
+# only contain underlines. From:
+# https://devguide.python.org/documentation/markup/#sections
+SECTION_CHARS = "#*|=-^\"'~+.`_:"
 ROLE_ALIASES = {
     "pep": "PEP",
     "pep-reference": "PEP",

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -19,18 +19,17 @@ from typing import (
 
 import black
 import docutils
+import docutils.nodes
 from black import Mode
 from blib2to3.pgen2.tokenize import TokenError
 from docutils import nodes
 from docutils.frontend import OptionParser
-from docutils.nodes import pending, tgroup
 from docutils.parsers import rst
 from docutils.parsers.rst import Directive, roles
 from docutils.transforms import Transform
 from docutils.utils import Reporter, new_document, unescape
 
 from . import rst_extras
-from .const import SECTION_CHARS
 from .exceptions import InvalidRstError, InvalidRstErrors
 from .rst_extras import _add_directive, generic_role
 from .util import get_code_line, make_enumerator
@@ -142,6 +141,7 @@ class FormatContext:
         self.ordinal_format = "arabic"
         self.section_depth = 0
         self.subsequent_indent = 0
+        self.use_adornments = None
         for key, value in kwargs.items():
             setattr(self, key, value)
 
@@ -204,7 +204,7 @@ class CodeFormatters:
                     self.context.manager.reporter.error(
                         f"SyntaxError: {syntax_error.msg}:\n\nFile"
                         f' "{self.context.current_file}", line'
-                        f' {document_line + syntax_error.lineno}:\n{syntax_error.text}\n{" " * (syntax_error.offset - 1)}^'
+                        f" {document_line + syntax_error.lineno}:\n{syntax_error.text}\n{' ' * (syntax_error.offset - 1)}^"
                     )
         return self.code
 
@@ -215,6 +215,7 @@ class Manager:
         reporter: Reporter,
         black_config: Mode = None,
         docstring_trailing_line: bool = True,
+        section_adornments: list[tuple[str, bool]] | None = None,
     ):
         rst_extras.register()
         self.black_config = black_config
@@ -230,6 +231,7 @@ class Manager:
         self.formatters = Formatters(self)
         self.current_file = None
         self.docstring_trailing_line = docstring_trailing_line
+        self.section_adornments = section_adornments
 
     def _patch_unknown_directives(self, text: str) -> None:
         doc = new_document(str(self.current_file), self.settings)
@@ -320,6 +322,47 @@ class Manager:
         )
         return f"{formatted_node}\n"
 
+    def _register_adornments(
+        self, input_lines: list[str], document: docutils.nodes.document
+    ) -> None:
+        """Register adornments from source text on all individual sections.
+
+        This method will parse the document tree and original text to-be-formatted, and
+        will register, at the document tree, the current document configuration
+        representing the adornments for parts, chapters and sections on each level of
+        the document.  In particular, it will install an attribute called
+        ``adornment-character`` with the character used for underline or overlining the
+        section, and ``adornment-overline``, if the section should be overlined or not.
+
+        Parameters
+        ----------
+        input_lines
+            The lines of input (splitted by newline), that we must format.
+        document
+            The pre-parsed document tree, that will be modified with new section
+            attributes as described above.
+
+        """
+        for section in document.traverse(nodes.section):
+            title_node = section.next_node(nodes.title)
+            if (
+                title_node
+                and hasattr(title_node, "line")
+                and title_node.line is not None
+            ):
+                underline = input_lines[title_node.line - 1].strip()[0]
+                overline_lineno = title_node.line - 3
+                overline = False
+
+                if overline_lineno >= 0:
+                    candidate_overline = input_lines[overline_lineno].strip()
+                    if candidate_overline and candidate_overline[0] == underline:
+                        overline = True
+
+                # Store this information in the document tree
+                section["adornment-character"] = underline
+                section["adornment-overline"] = overline
+
     def parse_string(
         self, file_name: Path | str, text: str, line_offset: int = 0
     ) -> docutils.nodes.document:
@@ -333,7 +376,9 @@ class Manager:
         doc.reporter = IgnoreMessagesReporter(
             "", self.settings.report_level, self.settings.halt_level
         )
-        self._pre_process(doc, line_offset, len(text.splitlines()))
+        input_lines = text.splitlines()
+        self._pre_process(doc, line_offset, len(input_lines))
+        self._register_adornments(input_lines, doc)
         return doc
 
     def perform_format(
@@ -355,7 +400,6 @@ def pairwise(items: Iterable[T]) -> Iterator[tuple[T, T]]:
 
 
 class Formatters:
-
     @staticmethod
     def _chain_with_line_separator(
         separator: T, items: Iterable[Iterable[T]]
@@ -1077,7 +1121,7 @@ class Formatters:
         )
 
     def pending(
-        self, node: pending, context: FormatContext
+        self, node: docutils.nodes.pending, context: FormatContext
     ) -> inline_iterator:  # pragma: no cover
         msg = f'Unknown node found at File "{context.current_file}", line {node.line}'
         raise NotImplementedError(msg)
@@ -1255,7 +1299,7 @@ class Formatters:
         column_count = len(rows[0])
         total_width = context.width - column_count + 1
 
-        nested_column_count = len(list(node.findall(tgroup)))
+        nested_column_count = len(list(node.findall(docutils.nodes.tgroup)))
         table_matrix_min = self._generate_table_matrix(
             context, rows, (nested_column_count * 2) - 1
         )
@@ -1374,9 +1418,31 @@ class Formatters:
                 None, chain(self._format_children(node, context)), context, node.line
             )
         )
-        char = SECTION_CHARS[context.section_depth - 1]
-        yield text
-        yield char * len(text)
+        char: str = node.parent["adornment-character"]
+        overline: bool = node.parent["adornment-overline"]
+        if context.manager.section_adornments is not None:
+            try:
+                char, overline = context.manager.section_adornments[
+                    context.section_depth - 1
+                ]
+            except IndexError:
+                context.manager.reporter.error(
+                    f"Section at line {node.line} is at depth "
+                    f"{context.section_depth}, however there are only "
+                    f"{len(context.manager.section_adornments)} adornments to pick "
+                    f"from. You must review your inputs or change settings."
+                )
+                raise
+
+        if overline:
+            # section headings with overline are centered
+            yield char * (2 + len(text))
+            yield " " + text
+            yield char * (2 + len(text))
+        else:
+            # sections headings without overline are justified
+            yield text
+            yield char * len(text)
 
     def title_reference(
         self, node: docutils.nodes.title_reference, context: FormatContext

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import glob
+import itertools
 import logging
 import os
 import signal
@@ -34,7 +35,7 @@ from libcst import CSTTransformer, Expr
 from libcst.metadata import ParentNodeProvider, PositionProvider
 
 from . import __version__
-from .const import DEFAULT_EXCLUDE
+from .const import DEFAULT_EXCLUDE, SECTION_CHARS
 from .debug import dump_node
 from .docstrfmt import Manager
 from .exceptions import InvalidRstErrors
@@ -58,11 +59,12 @@ def _format_file(
     line_length: int,
     mode: Mode,
     docstring_trailing_line: bool,
+    section_adornments: list[tuple[str, bool]] | None,
     raw_output: bool,
     lock: Lock,
 ):
     error_count = 0
-    manager = Manager(reporter, mode, docstring_trailing_line)
+    manager = Manager(reporter, mode, docstring_trailing_line, section_adornments)
     if file.name == "-":
         raw_output = True
     reporter.print(f"Checking {file}", 2)
@@ -273,12 +275,32 @@ def _resolve_length(context: click.Context, _: click.Parameter, value: int | Non
     return value or context.params.get("line_length", None)
 
 
+def _validate_adornments(
+    context: click.Context, _: click.Parameter, value: str | None
+) -> list[tuple[str, bool]]:
+    if value is None:
+        return value
+
+    if len(value) != len(set(value)):
+        msg = "Section adornments must be unique"
+        raise click.BadParameter(msg)
+
+    if "|" in value:
+        with_overline, without_overline = value.split("|", 1)
+        return list(zip(with_overline, itertools.repeat(True))) + list(
+            zip(without_overline, itertools.repeat(False))
+        )
+
+    return list(zip(value, itertools.repeat(False)))
+
+
 async def _run_formatter(
     check: bool,
     file_type: str,
     files: list[str],
     include_txt: bool,
     docstring_trailing_line: bool,
+    section_adornments: list[tuple[str, bool]] | None,
     mode: Mode,
     line_length: int,
     raw_output: bool,
@@ -305,6 +327,7 @@ async def _run_formatter(
                 line_length,
                 mode,
                 docstring_trailing_line,
+                section_adornments,
                 raw_output,
                 lock,
             )
@@ -448,14 +471,18 @@ class Visitor(CSTTransformer):
         )
 
     def leave_ClassDef(  # noqa: N802
-        self, original_node: ClassDef, updated_node: ClassDef  # noqa: ARG002
+        self,
+        original_node: ClassDef,
+        updated_node: ClassDef,  # noqa: ARG002
     ) -> ClassDef:
         """Remove the class name from the object name stack."""
         self._object_names.pop(-1)
         return updated_node
 
     def leave_FunctionDef(  # noqa: N802
-        self, original_node: FunctionDef, updated_node: FunctionDef  # noqa: ARG002
+        self,
+        original_node: FunctionDef,
+        updated_node: FunctionDef,  # noqa: ARG002
     ) -> FunctionDef:
         """Remove the function name from the object name stack."""
         self._object_names.pop(-1)
@@ -496,7 +523,7 @@ class Visitor(CSTTransformer):
             self.error_count += self.manager.error_count
             self.manager.error_count = 0
             object_display_name = (
-                f'{self._object_type} {".".join(self._object_names)!r}'
+                f"{self._object_type} {'.'.join(self._object_names)!r}"
             )
             single_line = len(output.splitlines()) == 1
             original_strip = original_node.evaluated_value.rstrip(" ")
@@ -622,6 +649,25 @@ class Visitor(CSTTransformer):
     callback=_resolve_length,
 )
 @click.option(
+    "-s",
+    "--section-adornments",
+    type=str,
+    default=None,
+    is_flag=False,
+    flag_value=SECTION_CHARS,
+    help=(
+        f"""Force pre-defined section adornments for part/chapter/section headers. If an
+        optional string is provided, it defines a sequence of adornments to use for each
+        individual section depth. The list must be composed of at least N **distinct**
+        characters for documents with N section depths.  Provide more if unsure.  If the
+        special character `|` (pipe) is used, then it defines sections (left portion)
+        that will have overlines besides underlines only (right portion). If this option
+        is not set, the default behaviour is to preserve existing adornments on your
+        document. An example set of adornments would be `{SECTION_CHARS}`."""
+    ),
+    callback=_validate_adornments,
+)
+@click.option(
     "-p",
     "--pyproject-config",
     "mode",
@@ -680,6 +726,7 @@ def main(  # noqa: PLR0912,PLR0915
     ignore_cache: bool,
     include_txt: bool,
     line_length: int,
+    section_adornments: list[tuple[str, bool]] | None,
     mode: Mode,
     quiet: bool,
     raw_input: str,
@@ -703,7 +750,7 @@ def main(  # noqa: PLR0912,PLR0915
             line_length = DEFAULT_LINE_LENGTH
     error_count = 0
     if raw_input:
-        manager = Manager(reporter, mode, docstring_trailing_line)
+        manager = Manager(reporter, mode, docstring_trailing_line, section_adornments)
         file = "<raw_input>"
         check = False
         try:
@@ -736,6 +783,7 @@ def main(  # noqa: PLR0912,PLR0915
                 line_length,
                 mode,
                 docstring_trailing_line,
+                section_adornments,
                 raw_output,
                 None,
             )
@@ -766,6 +814,7 @@ def main(  # noqa: PLR0912,PLR0915
                     files,
                     include_txt,
                     docstring_trailing_line,
+                    section_adornments,
                     mode,
                     line_length,
                     raw_output,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import textwrap
 
 import pytest
 import toml
@@ -714,3 +715,226 @@ def test_comment_preserve_single_line(runner):
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     assert result.output == fixed
+
+
+def test_section_invalid_adornments(runner):
+    file = """
+              ===
+              One
+              ===
+
+              Two
+              ---
+              Some content.
+           """
+
+    file = textwrap.dedent(file).lstrip()
+    args = ["-s", "#*|=-^\"'~+.`_:# ", "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 2
+    assert "Section adornments must be unique" in result.output
+
+
+def test_section_reformatting(runner):
+    file = """
+              ===
+              One
+              ===
+
+              Two
+              ---
+
+              Three
+              ~~~~~
+
+              Four
+              ++++
+
+              Five
+              ....
+
+              Six
+              '''
+
+              Two again
+              ---------
+
+              Some content.
+           """
+
+    fixed = """
+               =====
+                One
+               =====
+
+               Two
+               ---
+
+               Three
+               ~~~~~
+
+               Four
+               ++++
+
+               Five
+               ....
+
+               Six
+               '''
+
+               Two again
+               ---------
+
+               Some content.
+            """
+
+    file = textwrap.dedent(file).lstrip()
+    fixed = textwrap.dedent(fixed).lstrip()
+    args = ["-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == fixed
+
+
+def test_section_reformatting_python_adornments(runner):
+    file = """
+              ===
+              One
+              ===
+
+              Two
+              ---
+
+              Three
+              ~~~~~
+
+              Four
+              ++++
+
+              Five
+              ....
+
+              Six
+              '''
+
+              Two again
+              ---------
+
+              Some content.
+           """
+
+    fixed = """
+               #####
+                One
+               #####
+
+               *****
+                Two
+               *****
+
+               Three
+               =====
+
+               Four
+               ----
+
+               Five
+               ^^^^
+
+               Six
+               \"\"\"
+
+               ***********
+                Two again
+               ***********
+
+               Some content.
+            """
+
+    file = textwrap.dedent(file).lstrip()
+    fixed = textwrap.dedent(fixed).lstrip()
+    args = ["-s", "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == fixed
+
+
+def test_section_reformatting_custom_adornments(runner):
+    file = """
+              ===
+              One
+              ===
+
+              Two
+              ---
+
+              Three
+              ~~~~~
+
+              Four
+              ++++
+
+              Five
+              ....
+
+              Six
+              '''
+
+              Two again
+              ---------
+
+              Some content.
+           """
+
+    fixed = """
+               One
+               ###
+
+               Two
+               ***
+
+               Three
+               =====
+
+               Four
+               ----
+
+               Five
+               ^^^^
+
+               Six
+               \"\"\"
+
+               Two again
+               *********
+
+               Some content.
+            """
+
+    file = textwrap.dedent(file).lstrip()
+    fixed = textwrap.dedent(fixed).lstrip()
+    args = ["-s", '#*=-^"', "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == fixed
+
+
+def test_section_reformatting_insufficient_adornments(runner):
+    file = """
+              ===
+              One
+              ===
+
+              Two
+              ---
+
+              Three
+              ~~~~~
+              Some content.
+           """
+
+    file = textwrap.dedent(file).lstrip()
+    args = ["-s", "=:", "-r", file, "-o"]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 1
+    assert "there are only 2 adornments to pick from" in result.output


### PR DESCRIPTION
This PR closes #91 by implementing configurable section header adornments:

1. If the user does not explicitly request, by default the formatter keeps the current adornments. It still enforces centering of overlined headers, and full underlining of all other types of headers.
2. If the user signals via the `-s`/`--section-adornments` flag, but does not specify any adornments, then docstrfmt defaults to the adornments [recommended by Python](https://devguide.python.org/documentation/markup/#sections).
3. Finally, the user may pass an optional argument with the `-s`/`--section-adorments` flag to indicate which adornments should be consistently used throughout. Examples are provided at the CLI help message.