### PR TITLE
use builtin tomllib in python 3.11+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
   be installed alongside other packages more easily.
 - Comment blocks that do not contain new-line characters are now kept on a single output
   line.
+- In Python 3.11+, use ``tomllib`` to parse ``pyproject.toml``.
 
 **Removed**
 

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -21,7 +21,10 @@ from typing import TYPE_CHECKING, Any
 
 import click
 import libcst as cst
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib as toml
+else:
+    import toml
 from black import (
     DEFAULT_LINE_LENGTH,
     Mode,
@@ -122,7 +125,11 @@ def _parse_pyproject_config(
         value = pyproject_toml if pyproject_toml else None
     if value:
         try:
-            pyproject_toml = toml.load(value)
+            if sys.version_info >= (3, 11):
+                with open(value, "rb") as f:
+                    pyproject_toml = toml.load(f)
+            else:
+                pyproject_toml = toml.load(value)
             config = pyproject_toml.get("tool", {}).get("docstrfmt", {})
             config = {
                 k.replace("--", "").replace("-", "_"): v for k, v in config.items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "platformdirs>=4",
   "sphinx>=7",
   "tabulate>=0.9",
-  "toml>=0.10"
+  "toml>=0.10;python_version<'3.11'"
 ]
 dynamic = ["version", "description"]
 keywords = ["black", "docutils", "autoformatter", "formatter", "lint", "restructuredtext", "rst", "sphinx"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,10 @@ import subprocess
 import sys
 
 import pytest
-import toml
+try:
+    import tomllib as toml
+except ImportError:
+    import toml
 from black import DEFAULT_LINE_LENGTH
 
 from docstrfmt.main import main
@@ -389,7 +392,11 @@ def test_line_length_resolution__black_docstrfmt_set(runner):
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     assert result.output.startswith("Reformatted")
-    toml_config = toml.load(args[1])
+    if sys.version_info >= (3, 11):
+        with open(args[1], "rb") as f:
+            toml_config = toml.load(f)
+    else:
+        toml_config = toml.load(args[1])
     result = runner.invoke(
         main, args=args + ["-l", toml_config["tool"]["docstrfmt"]["line-length"]]
     )
@@ -403,7 +410,11 @@ def test_line_length_resolution__black_set(runner):
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     assert result.output.startswith("Reformatted")
-    toml_config = toml.load(args[1])
+    if sys.version_info >= (3, 11):
+        with open(args[1], "rb") as f:
+            toml_config = toml.load(f)
+    else:
+        toml_config = toml.load(args[1])
     result = runner.invoke(
         main, args=args + ["-l", toml_config["tool"]["black"]["line-length"]]
     )
@@ -428,7 +439,11 @@ def test_line_length_resolution__docstrfmt_set(runner):
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     assert result.output.startswith("Reformatted")
-    toml_config = toml.load(args[1])
+    if sys.version_info >= (3, 11):
+        with open(args[1], "rb") as f:
+            toml_config = toml.load(f)
+    else:
+        toml_config = toml.load(args[1])
     result = runner.invoke(
         main, args=args + ["-l", toml_config["tool"]["docstrfmt"]["line-length"]]
     )


### PR DESCRIPTION
`toml` has some issues with parsing some `pyproject.toml` files:

https://github.com/uiri/toml/issues/449

Since `tomllib` is built-in to python 3.11+, this PR prefers `tomllib` and falls back to `toml` in earlier python versions.

`toml` marked as dependency for less than 3.11 only.