### PR TITLE
Fix formatting Python code blocks with continuation lines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@
 - Image and Unicode substitution definitions were not being formatted correctly.
 - Files specified in pyproject are now parsed correctly.
 - Fixed issue when loading cache in certain environments.
+- Fixed formatting of Python code blocks with continuation lines in docstrings.
 
 **Removed**
 

--- a/tests/test_files/py_file.py
+++ b/tests/test_files/py_file.py
@@ -122,6 +122,16 @@ class ExampleClass:
         4
         >>> import this
 
+        >>> try:
+        ...     value = {1: 2}[3]
+        ... except KeyError:
+        ...     value = 4
+        ...
+        ... print(
+        ...     {"some long long long long long long long long long key to force line wrap": value}
+        ... )
+        {"some long long long long long long long long long key to force line wrap": value}
+
         """
         my_position, im_active = 1, True
         match my_position, im_active:


### PR DESCRIPTION
Simplify doctest parsing to format each example independently, emit a single `>>>` for the first formatted line and `...` for continuation lines (preserving empty continuation lines).

Fixes #168 