### PR TITLE
Fix stale cache hits when formatting options change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@
   within the content body of the directive.
 - Fixed an issue where ``:literal:`` roles were being replaced with literal formatting
   (surrounded with ``) when the literal string ended with an escaped space or ``\n``.
+- Fixed stale cache hits when formatting options change: the file cache key now
+  incorporates every option that affects output (e.g., ``--section-adornments``,
+  ``--bullet-list-marker``), so files reformat instead of being skipped after such
+  options change.
 
 ********************
  2.0.2 (2026/02/07)

--- a/docstrfmt/util.py
+++ b/docstrfmt/util.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import pickle
 import tempfile
 from collections import defaultdict
@@ -59,6 +60,23 @@ def make_enumerator(ordinal: int, sequence: str, fmt: tuple[str, str]) -> str:
 class FileCache:
     """A class to manage the cache of files."""
 
+    # Parameters that do not affect how a given file is formatted and therefore
+    # must not influence the cache key.
+    _NON_FORMATTING_PARAMS = frozenset(
+        [
+            "check",
+            "exclude",
+            "extend_exclude",
+            "files",
+            "ignore_cache",
+            "mode",
+            "quiet",
+            "raw_input",
+            "raw_output",
+            "verbose",
+        ]
+    )
+
     @staticmethod
     def _get_file_info(file: Path) -> tuple[float, int]:
         """Get the file info.
@@ -88,20 +106,22 @@ class FileCache:
     def _get_cache_filename(self) -> Path:
         """Get the cache filename.
 
+        The filename incorporates every parameter that affects formatting output
+        (e.g., ``section_adornments``, ``bullet_list_marker``) so that changing any
+        of them invalidates previously cached results.
+
         :returns: Path to the cache file.
 
         """
-        docstring_trailing_line = str(self.context.params["docstring_trailing_line"])
-        format_python_code_blocks = str(
-            self.context.params["format_python_code_blocks"]
-        )
-        line_length = str(self.context.params["line_length"])
-        mode = self.context.params["mode"].get_cache_key()
-        include_txt = str(self.context.params["include_txt"])
-        return (
-            self.cache_dir
-            / f"cache.{f'{docstring_trailing_line}_{format_python_code_blocks}_{include_txt}_{line_length}_{mode}'}.pickle"
-        )
+        params = self.context.params
+        parts = [
+            f"{name}={params[name]!r}"
+            for name in sorted(params)
+            if name not in self._NON_FORMATTING_PARAMS
+        ]
+        parts.append(f"mode={params['mode'].get_cache_key()}")
+        key = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+        return self.cache_dir / f"cache.{key}.pickle"
 
     def _read_cache(self) -> dict[str, tuple[float, int]]:
         """Read the cache file.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -741,6 +741,26 @@ def test_cache(runner, file):
     assert result.output.endswith("was checked.\nDone! 🎉\n")
 
 
+def test_cache_invalidated_by_formatting_options(runner):
+    # Two files are needed so that the parallel code path, which is the only one
+    # that uses the cache, runs.
+    files = ["tests/test_files/test_file.rst", "tests/test_files/py_file.py"]
+    args = ["-l", 80, *files]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output.endswith("were reformatted.\nDone! 🎉\n")
+
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output.endswith("was checked.\nDone! 🎉\n")
+
+    # Changing an option that affects output must invalidate the cache; the files
+    # need reformatting under the new section adornments.
+    result = runner.invoke(main, args=[*args, "-s", "|=-^\"'~+.`_:#*"])
+    assert result.exit_code == 0
+    assert result.output.endswith("were reformatted.\nDone! 🎉\n")
+
+
 def test_comment_preserve_single_line(runner):
     file = "..  A comment in a single line is not placed on the next one.\n"
     fixed = ".. A comment in a single line is not placed on the next one.\n"


### PR DESCRIPTION
## The bug

`FileCache._get_cache_filename()` builds the cache key from `docstring_trailing_line`, `format_python_code_blocks`, `include_txt`, `line_length`, and the black mode — but not from other output-affecting options like `--section-adornments`, `--bullet-list-marker`, `--center-section-titles`, or `--preserve-adornments`. Changing any of those reuses cache entries recorded under the old settings, so docstrfmt reports files as already formatted when they aren't.

We hit this in praw-dev/praw#2109: after removing a custom `section-adornments` setting from pyproject.toml, local docstrfmt runs kept reporting the repo clean from stale cache entries while CI (cold cache) correctly wanted 142 files reformatted. It made for a fun afternoon of chasing phantom sphinx-version and platform differences. 😄

## The fix

Build the cache filename from a hash of every CLI parameter *except* a denylist of options known not to affect output (`--check`, `--exclude`, `--verbose`, etc.). This way any future formatting option is automatically part of the key — the failure mode of forgetting to update the denylist is a too-eager cache miss rather than a wrong cache hit.

## Test note

While writing the regression test I noticed the single-file code path (`len(files) < 2`) never consults or writes the cache at all — only the parallel path does. The new test therefore passes two files. Happy to file that as a separate issue if it's not intentional.