### PR TITLE
Use the file cache for single-file invocations

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,9 @@
 ###############
 
 - Danny Zhu <dzhu@dzhu.us> `@dzhu <https://github.com/dzhu>`_
+
+##############
+ Contributors
+##############
+
+- Bryce Boe <bbzbryce@gmail.com> `@bboe <https://github.com/bboe>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@
   incorporates every option that affects output (e.g., ``--section-adornments``,
   ``--bullet-list-marker``), so files reformat instead of being skipped after such
   options change.
+- Single-file invocations now use the file cache; previously only runs with two or more
+  files consulted and updated it.
 
 ********************
  2.0.2 (2026/02/07)

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -501,8 +501,13 @@ async def _run_formatter(
                 if misformatted:
                     misformatted_files.add(file)
                 if (
-                    not (misformatted and raw_output) or (check and not misformatted)
-                ) and errors == 0:
+                    file.name != "-"  # stdin cannot be cached
+                    and (
+                        not (misformatted and raw_output)
+                        or (check and not misformatted)
+                    )
+                    and errors == 0
+                ):
                     files_to_cache.append(file)
     if cancelled:  # pragma: no cover
         await asyncio.gather(*cancelled, return_exceptions=True)
@@ -1112,10 +1117,18 @@ def main(
 
     cache = FileCache(context, ignore_cache)
     if len(files) < 2:
-        for file in files:
+        if raw_output:
+            # Raw output must always be emitted, even for cached files.
+            todo = {Path(file).resolve() for file in files}
+        else:
+            todo, _already_done = cache.gen_todo_list(files)
+        files_to_cache = []
+        for file in (Path(f) for f in files):
+            if file.resolve() not in todo:
+                continue
             misformatted, error_count = _format_file(
                 check,
-                Path(file),
+                file,
                 file_type,
                 include_txt,
                 line_length,
@@ -1130,6 +1143,15 @@ def main(
             )
             if misformatted:
                 misformatted_files.add(file)
+            if (
+                file.name != "-"  # stdin cannot be cached
+                and not raw_output  # raw output does not modify the file
+                and not (check and misformatted)  # the file remains misformatted
+                and error_count == 0
+            ):
+                files_to_cache.append(file)
+        if files_to_cache:
+            cache.write_cache(files_to_cache)
 
     else:
         # This code is heavily based on that of psf/black

--- a/docstrfmt/util.py
+++ b/docstrfmt/util.py
@@ -154,8 +154,9 @@ class FileCache:
         todo, done = set(), set()
         for file in (Path(f).resolve() for f in files):
             if (
-                self.cache.get(str(file)) != self._get_file_info(file)
+                file.name == "-"  # stdin cannot be cached
                 or self.ignore_cache
+                or self.cache.get(str(file)) != self._get_file_info(file)
             ):
                 todo.add(file)
             else:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -742,8 +742,7 @@ def test_cache(runner, file):
 
 
 def test_cache_invalidated_by_formatting_options(runner):
-    # Two files are needed so that the parallel code path, which is the only one
-    # that uses the cache, runs.
+    # Two files are used so that the parallel code path runs.
     files = ["tests/test_files/test_file.rst", "tests/test_files/py_file.py"]
     args = ["-l", 80, *files]
     result = runner.invoke(main, args=args)
@@ -759,6 +758,28 @@ def test_cache_invalidated_by_formatting_options(runner):
     result = runner.invoke(main, args=[*args, "-s", "|=-^\"'~+.`_:#*"])
     assert result.exit_code == 0
     assert result.output.endswith("were reformatted.\nDone! 🎉\n")
+
+
+def test_cache_single_file(runner):
+    file = "tests/test_files/test_file.rst"
+    args = ["-l", 80, file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output.endswith("were reformatted.\nDone! 🎉\n")
+
+    # Corrupt the formatting while preserving mtime and size so that a cache hit
+    # is distinguishable from a re-process: only a cache hit skips the file.
+    stat = os.stat(file)
+    with open(file, encoding="utf-8") as f:
+        content = f.read()
+    assert "\n- " in content
+    with open(file, "w", encoding="utf-8") as f:
+        f.write(content.replace("\n- ", "\n* ", 1))
+    os.utime(file, (stat.st_atime, stat.st_mtime))
+
+    result = runner.invoke(main, args=["-c", *args])
+    assert result.exit_code == 0
+    assert result.output.endswith("was checked.\nDone! 🎉\n")
 
 
 def test_comment_preserve_single_line(runner):


### PR DESCRIPTION
Closes #208

The `len(files) < 2` path called `_format_file` directly without consulting `gen_todo_list()` or calling `write_cache()`, so single-file runs always re-processed the file and never recorded it.

This routes the single-file path through the same cache flow as the parallel path, but with corrected cache-write semantics rather than a copy of the parallel branch's condition:

- **stdin (`-`)** is never cached; `gen_todo_list()` now also treats it as always-todo (previously the parallel path would `stat()` a literal `-` path), and checks `ignore_cache` before stat-ing.
- **`--raw-output`** bypasses the cache lookup (its output must be emitted every run) and never caches (the file on disk isn't modified).
- **check mode** doesn't cache files that remain misformatted — note the parallel branch's existing condition does cache these (and caches clean raw-output files); I deliberately left that branch alone since #196 is already addressing check-mode caching there.

The regression test corrupts a cached file's formatting while restoring its mtime and size, so a cache hit (file skipped, exit 0) is distinguishable from a re-process (exit 1) — output strings alone can't tell the two apart.

Second commit adds me to AUTHORS.rst.