### PR TITLE
Add --indent-width to control spaces per indent level.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@
  Unreleased
 ************
 
+**Added**
+
+- Added command-line option ``--indent-width`` (4 as default) to control
+  spaces per indent level.
+
 ********************
  2.1.1 (2026/06/12)
 ********************

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -370,6 +370,7 @@ class Manager:
         bullet_list_marker: str = "-",
         docstring_trailing_line: bool = True,
         format_python_code_blocks: bool = True,
+        indent_width: int = 4,
         reporter: Reporter | utils.Reporter | logging.Logger,
         section_adornments: list[tuple[str, bool]] | None = None,
     ):
@@ -383,6 +384,7 @@ class Manager:
         :param bullet_list_marker: Bullet character to use for unordered lists.
         :param docstring_trailing_line: Whether to add trailing line to docstrings.
         :param format_python_code_blocks: Whether to format Python code blocks.
+        :param indent_width: Number of spaces per indentation level.
         :param section_adornments: Section adornment configuration.
 
         """
@@ -404,6 +406,7 @@ class Manager:
         self.original_text = ""
         self.docstring_trailing_line = docstring_trailing_line
         self.format_python_code_blocks = format_python_code_blocks
+        self.indent_width = indent_width
         self._in_docstring = False  # for resolving line numbers in code blocks
         self.section_adornments = section_adornments
 
@@ -820,9 +823,12 @@ class Formatters:
         yield f".. {node.tagname}::"
         yield ""
         yield from _with_spaces(
-            4,
+            context.manager.indent_width,
             _chain_with_line_separator(
-                "", self._format_children(node, context.indent(4))
+                "",
+                self._format_children(
+                    node, context.indent(context.manager.indent_width)
+                ),
             ),
         )
 
@@ -849,9 +855,9 @@ class Formatters:
             f" {''.join(_wrap_text(None, chain(self._format_children(title, context)), context, node.line))}"
         )
         yield ""
-        context = context.indent(4)
+        context = context.indent(context.manager.indent_width)
         yield from _with_spaces(
-            4,
+            context.manager.indent_width,
             _chain_with_line_separator(
                 "",
                 (
@@ -883,9 +889,12 @@ class Formatters:
 
         """
         yield from _with_spaces(
-            4,
+            context.manager.indent_width,
             _chain_with_line_separator(
-                "", self._format_children(node, context.indent(4))
+                "",
+                self._format_children(
+                    node, context.indent(context.manager.indent_width)
+                ),
             ),
         )
 
@@ -940,7 +949,7 @@ class Formatters:
         yield ".."
         if node.children:
             text = "\n".join(chain(self._format_children(node, context)))
-            yield from _with_spaces(4, text.splitlines())
+            yield from _with_spaces(context.manager.indent_width, text.splitlines())
 
     def definition(
         self,
@@ -999,7 +1008,10 @@ class Formatters:
                 yield from self.manager.perform_format(child, context)
             elif isinstance(child, nodes.definition):
                 yield from _with_spaces(
-                    4, self.manager.perform_format(child, context.indent(4))
+                    context.manager.indent_width,
+                    self.manager.perform_format(
+                        child, context.indent(context.manager.indent_width)
+                    ),
                 )
 
     def directive(
@@ -1041,7 +1053,7 @@ class Formatters:
 
         yield " ".join(parts)
         # Just rely on the order being stable, hopefully.
-        leading_space = "" if in_substitution else " " * 4
+        leading_space = "" if in_substitution else " " * context.manager.indent_width
         for k, v in directive.options.items():
             yield f"{leading_space}:{k}:" if v is None else f"{leading_space}:{k}: {v}"
 
@@ -1055,9 +1067,11 @@ class Formatters:
                 except (AttributeError, TypeError):
                     pass
             yield ""
-            yield from _with_spaces(4, text.splitlines())
+            yield from _with_spaces(context.manager.indent_width, text.splitlines())
         elif directive.raw:
-            yield from _prepend_if_any("", _with_spaces(4, directive.content))
+            yield from _prepend_if_any(
+                "", _with_spaces(context.manager.indent_width, directive.content)
+            )
         else:
             sub_doc = self.manager.parse_string(
                 "\n".join(directive.content),
@@ -1067,7 +1081,10 @@ class Formatters:
             if sub_doc.children:
                 yield ""
                 yield from _with_spaces(
-                    4, self.manager.perform_format(sub_doc, context.indent(4))
+                    context.manager.indent_width,
+                    self.manager.perform_format(
+                        sub_doc, context.indent(context.manager.indent_width)
+                    ),
                 )
 
     def doctest_block(
@@ -1236,7 +1253,7 @@ class Formatters:
                 children_processed.append(child)
         children = children_processed
         yield f"{field_name} {first_line}"
-        yield from _with_spaces(4, children)
+        yield from _with_spaces(context.manager.indent_width, children)
 
     def field_body(
         self,
@@ -1256,8 +1273,9 @@ class Formatters:
             "",
             self._format_children(
                 node,
-                context.indent(4).wrap_first_at(
-                    len(f":{node.parent.children[0].astext()}: ") - 4
+                context.indent(context.manager.indent_width).wrap_first_at(
+                    len(f":{node.parent.children[0].astext()}: ")
+                    - context.manager.indent_width
                 ),
             ),
         )
@@ -1461,9 +1479,19 @@ class Formatters:
         """
         prefix = ".."
         children = _wrap_text(
-            (context.width - 4 if context.width is not None else None),
-            chain(self._format_children(node, context.indent(4))),
-            context.wrap_first_at(len(prefix) - 4).indent(4),
+            (
+                context.width - context.manager.indent_width
+                if context.width is not None
+                else None
+            ),
+            chain(
+                self._format_children(
+                    node, context.indent(context.manager.indent_width)
+                )
+            ),
+            context.wrap_first_at(len(prefix) - context.manager.indent_width).indent(
+                context.manager.indent_width
+            ),
             node.line,
         )
         footnote_name = (
@@ -1475,7 +1503,7 @@ class Formatters:
         yield " ".join([prefix, *footnote_name, child])
         remaining = list(children)
         if remaining:
-            yield from _with_spaces(4, remaining)
+            yield from _with_spaces(context.manager.indent_width, remaining)
 
     citation = footnote
 
@@ -1551,7 +1579,7 @@ class Formatters:
             yield "|"
             return
 
-        indent = 4 * context.line_block_depth
+        indent = context.manager.indent_width * context.line_block_depth
         context = context.indent(indent)
         prefix1 = f"|{' ' * (indent - 1)}"
         prefix2 = " " * indent
@@ -1684,11 +1712,13 @@ class Formatters:
             except (AttributeError, TypeError):
                 pass
             yield ""
-            yield from _with_spaces(4, text.splitlines())
+            yield from _with_spaces(context.manager.indent_width, text.splitlines())
             return
         else:
             yield "::"
-        yield from _prepend_if_any("", _with_spaces(4, node.rawsource.splitlines()))
+        yield from _prepend_if_any(
+            "", _with_spaces(context.manager.indent_width, node.rawsource.splitlines())
+        )
 
     def paragraph(
         self,
@@ -1955,19 +1985,33 @@ class Formatters:
             if _directive.options.get("alt") == node.attributes["names"][0]:
                 del _directive.options["alt"]
         if directive in ["image", "unicode"]:
-            children = chain(self._format_children(node, context.indent(4)))
+            children = chain(
+                self._format_children(
+                    node, context.indent(context.manager.indent_width)
+                )
+            )
         else:  # for date and replace
             children = _wrap_text(
-                (context.width - 4 if context.width is not None else None),
-                chain(self._format_children(node, context.indent(4))),
-                context.wrap_first_at(len(prefix) - 4).indent(4),
+                (
+                    context.width - context.manager.indent_width
+                    if context.width is not None
+                    else None
+                ),
+                chain(
+                    self._format_children(
+                        node, context.indent(context.manager.indent_width)
+                    )
+                ),
+                context.wrap_first_at(
+                    len(prefix) - context.manager.indent_width
+                ).indent(context.manager.indent_width),
                 node.line,
             )
         next_child = next(children)
         yield f"{prefix} {next_child}"
         remaining = list(children)
         if remaining:
-            yield from _with_spaces(4, remaining)
+            yield from _with_spaces(context.manager.indent_width, remaining)
 
     def substitution_reference(
         self,

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -68,6 +68,7 @@ def _format_file(
     lock: Lock | None,
     bullet_list_marker: str = "-",
     center_section_titles: bool = True,
+    indent_width: int = 4,
 ):
     """Format a single file with the given parameters.
 
@@ -84,6 +85,7 @@ def _format_file(
     :param lock: Lock for thread safety.
     :param bullet_list_marker: Bullet character to use for unordered lists.
     :param center_section_titles: Whether to center section titles with overlines.
+    :param indent_width: Number of spaces to use per indentation level.
 
     :returns: A tuple containing a boolean indicating if the file was misformatted and
         the number of errors.
@@ -97,6 +99,7 @@ def _format_file(
         center_section_titles=center_section_titles,
         docstring_trailing_line=docstring_trailing_line,
         format_python_code_blocks=format_python_code_blocks,
+        indent_width=indent_width,
         reporter=reporter,
         section_adornments=section_adornments,
     )
@@ -419,6 +422,7 @@ async def _run_formatter(
     executor: ProcessPoolExecutor | ThreadPoolExecutor,
     bullet_list_marker: str = "-",
     center_section_titles: bool = True,
+    indent_width: int = 4,
 ):
     """Run the formatter on multiple files asynchronously.
 
@@ -437,6 +441,7 @@ async def _run_formatter(
     :param executor: Process or thread pool executor.
     :param bullet_list_marker: Bullet character to use for unordered lists.
     :param center_section_titles: Whether to center section titles with overlines.
+    :param indent_width: Number of spaces per indentation level.
 
     :returns: Tuple of (misformatted_files, total_error_count).
 
@@ -466,6 +471,7 @@ async def _run_formatter(
                 lock,
                 bullet_list_marker,
                 center_section_titles,
+                indent_width,
             )
         ): file
         for file in sorted(todo)
@@ -928,6 +934,14 @@ class Visitor(CSTTransformer):
     is_flag=True,
 )
 @click.option(
+    "-w",
+    "--indent-width",
+    type=click.IntRange(3, 4),
+    default=4,
+    show_default=True,
+    help="Number of spaces per indentation level. Must be 3 or 4.",
+)
+@click.option(
     "-l",
     "--line-length",
     type=click.IntRange(4),
@@ -1023,6 +1037,7 @@ def main(
     format_python_code_blocks: bool,
     ignore_cache: bool,
     include_txt: bool,
+    indent_width: int,
     line_length: int,
     preserve_adornments: bool,
     mode: Mode,
@@ -1046,6 +1061,7 @@ def main(
     :param format_python_code_blocks: Whether to format Python code blocks.
     :param ignore_cache: Whether to ignore the cache.
     :param include_txt: Whether to include .txt files.
+    :param indent_width: Number of spaces per indentation level.
     :param line_length: Maximum line length.
     :param preserve_adornments: Whether to preserve existing section adornments.
     :param mode: Black formatting mode.
@@ -1084,6 +1100,7 @@ def main(
             center_section_titles=center_section_titles,
             docstring_trailing_line=docstring_trailing_line,
             format_python_code_blocks=format_python_code_blocks,
+            indent_width=indent_width,
             reporter=reporter,
             section_adornments=section_adornments,
         )
@@ -1132,6 +1149,7 @@ def main(
                 None,
                 bullet_list_marker,
                 center_section_titles,
+                indent_width,
             )
             if misformatted:
                 misformatted_files.add(file)
@@ -1179,6 +1197,7 @@ def main(
                     executor,
                     bullet_list_marker,
                     center_section_titles,
+                    indent_width,
                 )
             )
         finally:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -140,6 +140,54 @@ def test_bullet_list_marker_default(runner):
     assert result.output == "- item one\n- item two\n"
 
 
+@pytest.mark.parametrize("width", [3, 4])
+def test_indent_width(runner, width):
+    # A directive body, a definition list, and a directive option all use the
+    # configured indentation level.
+    source = (
+        ".. note::\n"
+        "\n"
+        "      Some note text.\n"
+        "\n"
+        "Term\n"
+        "      Definition body.\n"
+        "\n"
+        ".. image:: foo.png\n"
+        "      :alt: alt text\n"
+    )
+    args = ["--indent-width", width, "-"]
+    result = runner.invoke(main, args=args, input=source)
+    assert result.exit_code == 0
+    indent = " " * width
+    expected = (
+        ".. note::\n"
+        "\n"
+        f"{indent}Some note text.\n"
+        "\n"
+        "Term\n"
+        f"{indent}Definition body.\n"
+        "\n"
+        ".. image:: foo.png\n"
+        f"{indent}:alt: alt text\n"
+    )
+    assert result.output == expected
+
+
+def test_indent_width_short_flag(runner):
+    source = ".. note::\n\n      Some note text.\n"
+    result = runner.invoke(main, args=["-w", 3, "-"], input=source)
+    assert result.exit_code == 0
+    assert result.output == ".. note::\n\n   Some note text.\n"
+
+
+def test_indent_width_default(runner):
+    # Without the option the default indentation level is 4 spaces.
+    source = ".. note::\n\n      Some note text.\n"
+    result = runner.invoke(main, args=["-"], input=source)
+    assert result.exit_code == 0
+    assert result.output == ".. note::\n\n    Some note text.\n"
+
+
 def test_nested_bullet_in_enumerated_list_preserves_bullets(runner):
     """A bullet list nested inside an enumerated list must stay bulleted.
 


### PR DESCRIPTION
This adds an option to get the (arguably) standard 3 space indents by using `--indent-width 3`.

I selected the argument name -indent-width to match what clang-format calls the equivalent.

Fixes #158.

Tests were initially made with claude code (then cleaned up, hopefully sufficiently....).

If you take this I don't personally need a version pushed.
