### PR TITLE
Fix references containing a backslash or backtick being emitted unescaped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@
 - Added command-line option ``--indent-width`` (4 as default) to control
   spaces per indent level.
 
+**Fixed**
+
+- Fixed references containing a backslash or backtick being emitted unescaped.
+
 ********************
  2.1.1 (2026/06/12)
 ********************

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -1798,11 +1798,16 @@ class Formatters:
             :ref:`Link text <target>`
 
         """
+
+        # docutils delivers the title and target with backslash escapes already
+        # consumed, so any literal backslashes and backticks must be re-escaped
+        def escape(value: str) -> str:
+            return value.replace("\\", "\\\\").replace("`", r"\`")
+
         attributes = node.attributes
-        target = attributes["target"]
+        target = escape(attributes["target"])
         if attributes["has_explicit_title"]:
-            title = attributes["title"].replace("<", r"\<")
-            title = title.replace("`", r"\`")
+            title = escape(attributes["title"]).replace("<", r"\<")
             text = f"{title} <{target}>"
         else:
             text = target

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -234,6 +234,16 @@ def test_encoding(runner):
     assert result.output == "1 file was checked.\nDone! 🎉\n"
 
 
+def test_ref_role_escapes_target(runner):
+    """Test escaped targets."""
+    source = (
+        "the :option:`\\`v`\n\nthe :option:`a\\`b <c\\`d>`\n\nthe :option:`a\\\\b`\n"
+    )
+    result = runner.invoke(main, args=["-"], input=source)
+    assert result.exit_code == 0
+    assert result.output == source
+
+
 def test_encoding_raw_input(runner):
     file = (
         ".. note::\n\n    á Á à À â Â ä Ä ã Ã å Å æ Æ ç Ç é É è È ê Ê ë Ë í Í ì Ì î Î ï"


### PR DESCRIPTION
Fix references containing a backslash or backtick being emitted unescaped.

Assisted with Claude AI, but manually reviewed and corrected.

No need to push new release on my account, expect 2 more pulls.
