### PR TITLE
Add command-line option --ordered-marker.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 
 - Added command-line option ``--indent-width`` (4 as default) to control
   spaces per indent level.
+- Added command-line option ``--ordered-marker``.
+  Default ``1`` keeps explicit numbering; ``#`` uses ``#`` auto-enumerator.
 
 **Fixed**
 

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -371,6 +371,7 @@ class Manager:
         docstring_trailing_line: bool = True,
         format_python_code_blocks: bool = True,
         indent_width: int = 4,
+        ordered_marker: str = "1",
         reporter: Reporter | utils.Reporter | logging.Logger,
         section_adornments: list[tuple[str, bool]] | None = None,
     ):
@@ -385,6 +386,7 @@ class Manager:
         :param docstring_trailing_line: Whether to add trailing line to docstrings.
         :param format_python_code_blocks: Whether to format Python code blocks.
         :param indent_width: Number of spaces per indentation level.
+        :param ordered_marker: Marker style for ordered (enumerated) lists, 1 or #.
         :param section_adornments: Section adornment configuration.
 
         """
@@ -393,6 +395,7 @@ class Manager:
         self.black_config = black_config
         self.center_section_titles = center_section_titles
         self.bullet_list_marker = bullet_list_marker
+        self.ordered_marker = ordered_marker
         self.current_offset = 0
         self.error_count = 0
         self.reporter = reporter
@@ -1186,11 +1189,17 @@ class Formatters:
             3. Third item
 
         """
+        start = node.attributes.get("start", 1)
+        enumtype = node.attributes["enumtype"]
+        if (
+            context.manager.ordered_marker == "#"
+            and enumtype == "arabic"
+            and start == 1
+        ):
+            enumtype = "#"
         yield from self._list(
             node,
-            context.with_ordinal(node.attributes.get("start", 1)).with_ordinal_format(
-                node.attributes["enumtype"]
-            ),
+            context.with_ordinal(start).with_ordinal_format(enumtype),
         )
         context.current_ordinal = 0
 

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -69,6 +69,7 @@ def _format_file(
     bullet_list_marker: str = "-",
     center_section_titles: bool = True,
     indent_width: int = 4,
+    ordered_marker: str = "1",
 ):
     """Format a single file with the given parameters.
 
@@ -86,6 +87,7 @@ def _format_file(
     :param bullet_list_marker: Bullet character to use for unordered lists.
     :param center_section_titles: Whether to center section titles with overlines.
     :param indent_width: Number of spaces to use per indentation level.
+    :param ordered_marker: Marker style for ordered (enumerated) lists.
 
     :returns: A tuple containing a boolean indicating if the file was misformatted and
         the number of errors.
@@ -100,6 +102,7 @@ def _format_file(
         docstring_trailing_line=docstring_trailing_line,
         format_python_code_blocks=format_python_code_blocks,
         indent_width=indent_width,
+        ordered_marker=ordered_marker,
         reporter=reporter,
         section_adornments=section_adornments,
     )
@@ -423,6 +426,7 @@ async def _run_formatter(
     bullet_list_marker: str = "-",
     center_section_titles: bool = True,
     indent_width: int = 4,
+    ordered_marker: str = "1",
 ):
     """Run the formatter on multiple files asynchronously.
 
@@ -442,6 +446,7 @@ async def _run_formatter(
     :param bullet_list_marker: Bullet character to use for unordered lists.
     :param center_section_titles: Whether to center section titles with overlines.
     :param indent_width: Number of spaces per indentation level.
+    :param ordered_marker: Marker style for ordered (enumerated) lists.
 
     :returns: Tuple of (misformatted_files, total_error_count).
 
@@ -472,6 +477,7 @@ async def _run_formatter(
                 bullet_list_marker,
                 center_section_titles,
                 indent_width,
+                ordered_marker,
             )
         ): file
         for file in sorted(todo)
@@ -966,6 +972,16 @@ class Visitor(CSTTransformer):
     ),
 )
 @click.option(
+    "--ordered-marker",
+    default="1",
+    help=(
+        "Marker style for ordered (enumerated) lists. '1' keeps the explicit"
+        " numbering; '#' uses the '#' auto-enumerator."
+    ),
+    show_default=True,
+    type=click.Choice(["1", "#"]),
+)
+@click.option(
     "-pA",
     "--preserve-adornments",
     help="Preserve existing section adornments.",
@@ -1053,6 +1069,7 @@ def main(
     include_txt: bool,
     indent_width: int,
     line_length: int,
+    ordered_marker: str,
     preserve_adornments: bool,
     mode: Mode,
     quiet: bool,
@@ -1077,6 +1094,7 @@ def main(
     :param include_txt: Whether to include .txt files.
     :param indent_width: Number of spaces per indentation level.
     :param line_length: Maximum line length.
+    :param ordered_marker: Marker style for ordered (enumerated) lists.
     :param preserve_adornments: Whether to preserve existing section adornments.
     :param mode: Black formatting mode.
     :param quiet: Whether to suppress non-error output.
@@ -1115,6 +1133,7 @@ def main(
             docstring_trailing_line=docstring_trailing_line,
             format_python_code_blocks=format_python_code_blocks,
             indent_width=indent_width,
+            ordered_marker=ordered_marker,
             reporter=reporter,
             section_adornments=section_adornments,
         )
@@ -1164,6 +1183,7 @@ def main(
                 bullet_list_marker,
                 center_section_titles,
                 indent_width,
+                ordered_marker,
             )
             if misformatted:
                 misformatted_files.add(file)
@@ -1212,6 +1232,7 @@ def main(
                     bullet_list_marker,
                     center_section_titles,
                     indent_width,
+                    ordered_marker,
                 )
             )
         finally:

--- a/docstrfmt/util.py
+++ b/docstrfmt/util.py
@@ -28,7 +28,7 @@ def make_enumerator(ordinal: int, sequence: str, fmt: tuple[str, str]) -> str:
     :returns: The formatted enumerator string or None for invalid ordinals.
 
     """
-    if sequence == "#":  # pragma: no cover
+    if sequence == "#":
         enumerator = "#"
     elif sequence == "arabic":
         enumerator = str(ordinal)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -189,6 +189,38 @@ def test_bullet_list_marker_default(runner):
     assert result.output == "- item one\n- item two\n"
 
 
+def test_ordered_marker_hash_rewrites_numbers(runner):
+    """With "--ordered-marker #" a plain arabic list starting at 1 is rewritten to
+    use the "#" auto-enumerator, and an existing "#" list is kept as-is."""
+    result = runner.invoke(
+        main, args=["--ordered-marker", "#", "-"], input="1. Foo\n2. Bar\n"
+    )
+    assert result.exit_code == 0
+    assert result.output == "#. Foo\n#. Bar\n"
+
+    kept = runner.invoke(
+        main, args=["--ordered-marker", "#", "-"], input="#. One\n#. Two\n"
+    )
+    assert kept.exit_code == 0
+    assert kept.output == "#. One\n#. Two\n"
+
+
+def test_ordered_marker_hash_preserves_non_default_lists(runner):
+    """A "#" auto-enumerator always restarts at 1, so lists that cannot be
+    reproduced by it (a non-1 start, or a lettered sequence) keep their markers."""
+    non_one_start = runner.invoke(
+        main, args=["--ordered-marker", "#", "-"], input="3. Foo\n4. Bar\n"
+    )
+    assert non_one_start.exit_code == 0
+    assert non_one_start.output == "3. Foo\n4. Bar\n"
+
+    lettered = runner.invoke(
+        main, args=["--ordered-marker", "#", "-"], input="a. Foo\nb. Bar\n"
+    )
+    assert lettered.exit_code == 0
+    assert lettered.output == "a. Foo\nb. Bar\n"
+
+
 @pytest.mark.parametrize("width", [3, 4])
 def test_indent_width(runner, width):
     # A directive body, a definition list, and a directive option all use the


### PR DESCRIPTION
Adds an option to use '#` in place of numbers.

Closes #163.
Closes #195.

Will be conflicts with #220 and #221 due to options added, the resolution is obvious but I will resolve conflicts on the pulls as you merge each/whichever ones you like in whatever order.

With this, #220, #221 my project round-trips successfully, so would appreciate a release once all are in.
