### PR TITLE
Handle enum member docstrings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@
 - Added command-line option ``--indent-width`` (4 as default) to control
   spaces per indent level.
 
+**Fixed**
+
+- Fixed ``IndexError`` when checking attribute docstrings after ``enum.Enum`` members.
+
 ********************
  2.1.1 (2026/06/12)
 ********************

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -731,6 +731,16 @@ class Visitor(CSTTransformer):
                 break
         return node
 
+    @staticmethod
+    def _assign_target_name(node: AssignTarget) -> str | None:
+        """Return a display name for an attribute docstring target."""
+        target = node.target
+        if isinstance(target, cst.Name):
+            return target.value
+        if isinstance(target, cst.Attribute):
+            return target.attr.value
+        return None
+
     def leave_SimpleString(  # noqa: N802
         self, original_node: SimpleString, updated_node: SimpleString
     ) -> SimpleString:
@@ -745,8 +755,11 @@ class Visitor(CSTTransformer):
         if self._is_docstring(original_node):
             position_meta = self.get_metadata(PositionProvider, original_node)
             old_object_type = None
+            assigned_object_name = None
             if self._last_assign:
-                self._object_names.append(self._last_assign.target.children[2].value)  # type: ignore[attr]
+                assigned_object_name = self._assign_target_name(self._last_assign)
+                if assigned_object_name:
+                    self._object_names.append(assigned_object_name)
                 old_object_type = copy(self._object_type)
                 self._object_type = "attribute"
             indent_level = position_meta.start.column  # type: ignore[attr]
@@ -803,7 +816,8 @@ class Visitor(CSTTransformer):
                 updated_node = updated_node.with_changes(value=value)
             if self._last_assign:
                 self._last_assign = None
-                self._object_names.pop(-1)
+                if assigned_object_name:
+                    self._object_names.pop(-1)
                 self._object_type = old_object_type
         return self._escape_quoting(updated_node)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -122,6 +122,25 @@ def test_docstring_trailing_line(runner, flag):
         )
 
 
+def test_python_attribute_docstring_after_enum_member(runner):
+    file = '''
+              import enum
+
+              class TestStrEnum(enum.Enum):
+                  """Documentation for this type."""
+
+                  FOO = enum.auto()
+                  """Documentation for the FOO."""
+           '''
+
+    file = textwrap.dedent(file).lstrip()
+    ast.parse(file)  # check if input is valid Python code
+    args = ["-t", "py", "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == file
+
+
 @pytest.mark.parametrize("marker", ["-", "*"])
 def test_bullet_list_marker(runner, marker):
     bullet_input = "* item one\n* item two\n* item three\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,6 +141,36 @@ def test_python_attribute_docstring_after_enum_member(runner):
     assert result.output == file
 
 
+def test_python_docstring_after_tuple_assignment(runner):
+    file = '''
+              A, B = (1, 2)
+              """Documentation for two names."""
+           '''
+
+    file = textwrap.dedent(file).lstrip()
+    ast.parse(file)  # check if input is valid Python code
+    args = ["-t", "py", "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == file
+
+
+def test_python_docstring_after_attribute_assignment(runner):
+    file = '''
+              class Example:
+                  def method(self):
+                      self.value = 1
+                      """Documentation for value."""
+           '''
+
+    file = textwrap.dedent(file).lstrip()
+    ast.parse(file)  # check if input is valid Python code
+    args = ["-t", "py", "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == file
+
+
 @pytest.mark.parametrize("marker", ["-", "*"])
 def test_bullet_list_marker(runner, marker):
     bullet_input = "* item one\n* item two\n* item three\n"


### PR DESCRIPTION
Fixes #203.

The Python visitor was treating the string after an assignment as an attribute docstring, but it assumed the assignment target looked like an attribute access. Enum members use a plain name target, so reading a fixed child index raised `IndexError` before the docstring could be checked.

This keeps the existing attribute-docstring handling, adds safe name extraction for both plain names and attributes, and avoids assuming LibCST's internal child layout for other assignment forms.

Checked locally:

- `python -m pytest tests/test_main.py::test_python_attribute_docstring_after_enum_member -q`
- `python -m pytest tests/test_main.py -k "python_attribute_docstring_after_enum_member or docstring_reformatting_with_quotes" -q`
- direct `python -m docstrfmt` run against the issue reproducer
- `python -m py_compile docstrfmt/main.py tests/test_main.py`
- `git diff --check`