### PR TITLE
fix: use docutils column width for rst formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@
  Unreleased
 ************
 
+**Fixed**
+
+- Fixed rST width calculations for CJK/full-width and combining characters by
+  using docutils column width semantics for section titles, simple tables, and
+  line wrapping.
+
 ********************
  2.2.0 (2026/06/21)
 ********************

--- a/docstrfmt/docstrfmt.py
+++ b/docstrfmt/docstrfmt.py
@@ -27,7 +27,7 @@ from docutils.parsers import rst
 from docutils.parsers.rst import Directive, roles
 from docutils.statemachine import StringList
 from docutils.transforms import Transform
-from docutils.utils import new_document, unescape
+from docutils.utils import column_width, new_document, unescape
 
 from . import NODE_MAPPING, rst_extras
 from .exceptions import InvalidRstError, InvalidRstErrors
@@ -852,7 +852,7 @@ class Formatters:
                 [
                     max(
                         [
-                            len(line)
+                            column_width(line)
                             for child in self._format_children(
                                 cell, context.with_width(width=widths[column_index])
                             )
@@ -868,7 +868,7 @@ class Formatters:
             [
                 max(
                     [
-                        len(line)
+                        column_width(line)
                         for child in self._format_children(
                             cell, context.with_width(width=width)
                         )
@@ -1382,7 +1382,7 @@ class Formatters:
             self._format_children(
                 node,
                 context.indent(context.manager.indent_width).wrap_first_at(
-                    len(f":{node.parent.children[0].astext()}: ")
+                    column_width(f":{node.parent.children[0].astext()}: ")
                     - context.manager.indent_width
                 ),
             ),
@@ -1597,9 +1597,9 @@ class Formatters:
                     node, context.indent(context.manager.indent_width)
                 )
             ),
-            context.wrap_first_at(len(prefix) - context.manager.indent_width).indent(
-                context.manager.indent_width
-            ),
+            context.wrap_first_at(
+                column_width(prefix) - context.manager.indent_width
+            ).indent(context.manager.indent_width),
             node.line,
         )
         footnote_name = (
@@ -2029,7 +2029,7 @@ class Formatters:
         ]
         for line_group in itertools.zip_longest(*all_lines):  # type: ignore[arg-type]
             yield " ".join(
-                (line or "").ljust(width)
+                (line or "") + " " * max(0, width - column_width(line or ""))
                 for line, width in zip(line_group, context.column_widths, strict=False)
             )
 
@@ -2114,7 +2114,7 @@ class Formatters:
                     )
                 ),
                 context.wrap_first_at(
-                    len(prefix) - context.manager.indent_width
+                    column_width(prefix) - context.manager.indent_width
                 ).indent(context.manager.indent_width),
                 node.line,
             )
@@ -2397,21 +2397,22 @@ class Formatters:
                 )
                 raise
 
+        text_width = column_width(text)
         if overline:
             if context.manager.center_section_titles:
                 # section headings with overline are centered
-                yield char * (2 + len(text))
+                yield char * (2 + text_width)
                 yield " " + text
-                yield char * (2 + len(text))
+                yield char * (2 + text_width)
             else:
                 # section headings with overline are not centered
-                yield char * len(text)
+                yield char * text_width
                 yield text
-                yield char * len(text)
+                yield char * text_width
         else:
             # sections headings without overline are justified
             yield text
-            yield char * len(text)
+            yield char * text_width
 
     def title_reference(
         self,
@@ -2584,7 +2585,7 @@ def _wrap_text(
             current_line_length
             + (context.subsequent_indent if bool(words) else 0)
             + bool(words)
-            + len(word)
+            + column_width(word)
         )
         if words and next_line_len > width:
             yield " " * context.subsequent_indent + " ".join(words)
@@ -2592,7 +2593,7 @@ def _wrap_text(
                 width += context.first_line_len
                 context.first_line_len = 0
             words = []
-            next_line_len = len(word)
+            next_line_len = column_width(word)
         words.append(word)
         current_line_length = next_line_len
     if words:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ try:
 except ImportError:  # pragma: no cover
     import tomli as toml
 from black import DEFAULT_LINE_LENGTH
+from docutils.core import publish_doctree
 
 from docstrfmt.main import main
 
@@ -634,6 +635,20 @@ def test_invalid_table(runner):
         f" another file.\nFailed to format '{os.path.abspath(file)}'\n1 file was"
         " checked.\nDone, but 1 error occurred ❌💥❌\n"
     )
+
+
+def test_simple_table_cjk_width(runner):
+    source = "===== =====\n中文  abc\n===== =====\n"
+    expected = "==== ===\n中文 abc\n==== ===\n"
+
+    result = runner.invoke(main, args=["-"], input=source)
+    assert result.exit_code == 0
+    assert result.output == expected
+
+    doctree = publish_doctree(result.output)
+    assert [
+        node.astext() for node in doctree.findall() if node.tagname == "system_message"
+    ] == []
 
 
 @pytest.mark.parametrize("length", test_line_length)
@@ -1573,6 +1588,43 @@ def test_section_reformatting_no_center_titles(runner):
     file = textwrap.dedent(file).lstrip()
     fixed = textwrap.dedent(fixed).lstrip()
     args = ["--no-center-section-titles", "-r", file]
+    result = runner.invoke(main, args=args)
+    assert result.exit_code == 0
+    assert result.output == fixed
+
+
+def test_section_reformatting_docutils_title_width(runner):
+    file = """
+              ****
+              示例标题
+              ****
+
+              タイトル
+              ####
+
+              Café
+              =====
+
+              Some content.
+           """
+
+    fixed = """
+              **********
+               示例标题
+              **********
+
+              タイトル
+              ########
+
+              Café
+              ====
+
+              Some content.
+            """
+
+    file = textwrap.dedent(file).lstrip()
+    fixed = textwrap.dedent(fixed).lstrip()
+    args = ["-pA", "-r", file]
     result = runner.invoke(main, args=args)
     assert result.exit_code == 0
     assert result.output == fixed


### PR DESCRIPTION
Fix rST formatting width calculations to match docutils/Sphinx column width semantics.

## Bug Cause

The formatter previously used Python string length (`len(...)`) in places where rST/docutils expects visual column width. This is incorrect for CJK/full-width characters and combining marks, whose display width can differ from their Python character count.
This could cause:
- Section title overlines/underlines to be too short in Sphinx builds
- Simple tables with CJK/full-width content to be formatted into malformed rST tables
- CJK text wrapping to exceed the configured visual line length

## Changes

- Use `docutils.utils.column_width()` for section title adornment lengths.
- Use `column_width()` when calculating simple table column widths.
- Pad simple table cells based on visual column width instead of Python string length.
- Use `column_width()` for text wrapping width calculation.
- Align related first-line prefix width calculations with docutils semantics.
- Add regression tests for CJK section titles and simple tables.

## Validation

- All tests pass.
- Coverage remains at 100%.
- **`uv run tox` currently fails in the style environment** because tox installs Ruff 0.16.0, where `PLR0917` is enabled by the existing `select = ["PL", ...]` configuration. The reported functions already had too many positional-capable arguments before this PR, and this PR does not touch `docstrfmt/main.py`; therefore, this pre-existing style issue is left unchanged.