### PR TITLE
🐛 fix(cli): keep root files in formatter scope

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 
 **Fixed**
 
+- Fixed directory exclusions skipping root files when the invocation directory
+  shares an excluded name such as ``build``.
 - Fixed rST width calculations for CJK/full-width and combining characters by
   using docutils column width semantics for section titles, simple tables, and
   line wrapping.

--- a/docstrfmt/main.py
+++ b/docstrfmt/main.py
@@ -221,7 +221,9 @@ def _parse_pyproject_config(
     return Mode()
 
 
-def _parse_sources(context: click.Context, _: click.Parameter, value: list[str] | None):
+def _parse_sources(
+    context: click.Context, _: click.Parameter, value: list[str] | None
+) -> list[str]:
     """Parse and expand source files from command line arguments.
 
     :param context: Click context containing command parameters.
@@ -264,9 +266,13 @@ def _parse_sources(context: click.Context, _: click.Parameter, value: list[str] 
                         files_to_format.add(abspath(f))
                 else:
                     files_to_format.add(abspath(item))
+    root_dir = Path.cwd()
     for file in list(map(Path, files_to_format)):
         for exclusion in exclude:
-            if file.parent.match(exclusion) or file.match(exclusion):
+            if (
+                (file.parent != root_dir or Path(exclusion).is_absolute())
+                and file.parent.match(exclusion)
+            ) or file.match(exclusion):
                 files_to_format.discard(abspath(file))
                 break
     return sorted(files_to_format)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,10 @@ import os
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
 try:
     import tomllib as toml
@@ -44,6 +46,39 @@ def test_call(file):
         f"File '{os.path.abspath(file)}' could be reformatted.\n1 out of 1 file could"
         " be reformatted.\nDone! 🎉\n"
     )
+
+
+@pytest.mark.parametrize(
+    ("checkout_name", "source_parent", "exclude_checkout", "expected"),
+    [
+        ("build", ".", False, "1 file was checked.\nDone! 🎉\n"),
+        ("source", "build", False, "0 files was checked.\nDone! 🎉\n"),
+        ("source", ".", True, "0 files was checked.\nDone! 🎉\n"),
+    ],
+    ids=["checkout-root", "excluded-child", "absolute-root"],
+)
+def test_call_build_directory_exclusion(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    checkout_name: str,
+    source_parent: str,
+    exclude_checkout: bool,
+    expected: str,
+) -> None:
+    checkout = Path.cwd() / checkout_name
+    checkout.mkdir()
+    source = checkout / source_parent / "CHANGELOG.rst"
+    source.parent.mkdir(exist_ok=True)
+    source.write_text("Text.\n", encoding="utf-8")
+    monkeypatch.chdir(checkout)
+
+    args = ["--ignore-cache"]
+    if exclude_checkout:
+        args.extend(["--exclude", str(checkout)])
+    result = runner.invoke(main, args=[*args, str(source.relative_to(checkout))])
+
+    assert result.exit_code == 0
+    assert result.output == expected
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ requires-dist = [
     { name = "sphinx", specifier = ">=7" },
     { name = "tabulate", specifier = ">=0.10.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=0.10" },
-    { name = "types-docutils", specifier = "==0.22.3.20260518" },
+    { name = "types-docutils", specifier = "==0.22.3.20260724" },
 ]
 provides-extras = ["d"]
 
@@ -1745,11 +1745,11 @@ wheels = [
 
 [[package]]
 name = "types-docutils"
-version = "0.22.3.20260518"
+version = "0.22.3.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/91/81b520d0869a41aa0d86e713417b63e8604b4280c304bc09b02d74c7efd4/types_docutils-0.22.3.20260518.tar.gz", hash = "sha256:2c45ba63a9ac64246335359b68fe9c27602926499c9b67caec3780745f6aadee", size = 57504, upload-time = "2026-05-18T06:03:53.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/8f/30e02b59a9aad81eacd3d02fab5365257e89fde56e7acf44a4128f5f80aa/types_docutils-0.22.3.20260724.tar.gz", hash = "sha256:0223ce87f9b8331a5a3a7c7832e828033d289da6b878a0dcfbc74c30ec58850e", size = 57883, upload-time = "2026-07-24T04:58:36.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/9b/243fb84ede4f987f303a89e734c5def35ead2f8bd962ad301c1e99680958/types_docutils-0.22.3.20260518-py3-none-any.whl", hash = "sha256:9c4cbc37d9e37f47dfe971ac09e9880380dc948ff1f23956892e810d0bf08676", size = 91970, upload-time = "2026-05-18T06:03:52.388Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1a/898fbb98680dbd5eb7ac8e9cbaf39cf234d329a45d89d04faaf33d7d8008/types_docutils-0.22.3.20260724-py3-none-any.whl", hash = "sha256:45e2fe584608671aa648784c4f805d08a36cd69eb2bd542e60522140c46dc89c", size = 91986, upload-time = "2026-07-24T04:58:35.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`docstrfmt` drops root Python and RST files when the invocation directory shares a name with a relative exclusion. GitHub Actions checks out `pypa/build` to `/home/runner/work/build/build`, so the default `**/build` rule drops `CHANGELOG.rst` even when the release script passes that file by name ([release run](https://github.com/pypa/build/actions/runs/33115628309)).

The fix stops relative parent exclusions at the invocation root while preserving child-directory matches and absolute exclusions. The lockfile now matches the existing `types-docutils` pin required by the repository's `uv-lock` hook.
